### PR TITLE
chore: isolate GitHub Packages auth to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@org'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      - name: Configure GitHub Packages auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat <<'EOF' > ~/.npmrc
+          @org:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          always-auth=true
+          EOF
       - run: pnpm -w run lint && pnpm -w run test && pnpm -w run build
       - run: pnpm -r publish --access restricted
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,28 @@
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  quality:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [lint, typecheck, test, build]
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.10.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -w run ${{ matrix.task }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 coverage/
 .DS_Store
 .env
+*.tsbuildinfo

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@org:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-always-auth=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) where applicable.
+
+## [Unreleased]
+
+### Added
+- Baseline quality report capturing current install, lint, typecheck, test and build status.
+- Architectural decision record describing the new shared configuration packages.
+- Shared tooling packages for TypeScript, ESLint, Prettier and Jest foundations.
+- Repository directories for quality metrics, ADRs, migrations and runbooks.
+- Git keepers for migrations and runbooks to maintain directory structure.
+- Root Prettier configuration pointing to the shared preset.
+- Updated TypeScript and ESLint configs to consume workspace presets.
+- ADR 0002 documenting the enforcement of strict lint/type settings and CI gates.
+- Publish runbook describing safe GitHub Packages authentication for releases.
+
+### Changed
+- Replaced the Next.js TypeScript config with an `.mjs` variant to unblock `next lint` and let Next manage app compiler settings.
+- Normalised wizard infrastructure to rely on strongly typed module input and removed duplicate step registrations.
+- Tuned Turbo test outputs to avoid false cache warnings while coverage instrumentation is not yet enabled.
+- Hardened the shared TypeScript compiler defaults with additional strictness flags and introduced stricter ESLint rules for imports.
+- Replaced the multi-job CI setup with a matrix workflow that blocks on lint, typecheck, test and build failures.
+- Removed the repository-level `.npmrc`; publishing now generates scoped auth config in CI to avoid local token requirements.
+
+### Fixed
+- Resolved merge artefacts across shared calculation, schema, PDF and tooling modules so TypeScript and ESLint parse cleanly.
+- Restored review, PDF preview and storage utilities after conflict markers to ensure runtime components compile again.
+- Cleaned B1 calculation tests to eliminate duplicate suites and reinstate deterministic assertions.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # EAAS-Typescript
+
 ESG-as-a-Service (ESG reporting platform)
+
+## Repository docs
+
+- [Baseline quality metrics](docs/quality/baseline.md)
+- [Architectural decision records](docs/adr)
+- [Migrations](docs/migrations)
+- [Runbooks](docs/runbooks)
+- [Changelog](CHANGELOG.md)
+
+## Development quickstart
+
+- Install dependencies with `pnpm install`.
+- Run the core quality gates locally via `pnpm -w run lint`, `pnpm -w run typecheck`, `pnpm -w run test` og `pnpm -w run build`.
+- Format code with `pnpm run format` (or check via `pnpm run format:check`).
+- CI kører de samme kvalitetskontroller på hver pull request.
+
+## Publishing
+
+- Se [publish-runbooken](docs/runbooks/publishing.md) for hvordan du genererer en midlertidig `~/.npmrc`, når du skal udgive pakker.
+- Almindelig udvikling kræver ingen GitHub Packages token længere; adgangen konfigureres kun under release.

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["@org/eslint-config/next"]
 }

--- a/apps/web/app/(review)/review/page.tsx
+++ b/apps/web/app/(review)/review/page.tsx
@@ -3,17 +3,14 @@
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { CSSProperties } from 'react'
 import Link from 'next/link'
-import type { CalculatedModuleResult } from '@org/shared'
-*/
-'use client'
-import Link from 'next/link'
-import { useLiveResults } from '../../../features/results/useLiveResults'
-import { downloadReport } from '../../../features/pdf/downloadClient'
-import { PrimaryButton } from '../../../components/ui/PrimaryButton'
+import { useMemo, type CSSProperties } from 'react'
 
+import { PrimaryButton } from '../../../components/ui/PrimaryButton'
+import { downloadReport } from '../../../features/pdf/downloadClient'
+import { useLiveResults } from '../../../features/results/useLiveResults'
+
+import type { CalculatedModuleResult } from '@org/shared'
 
 const cardStyle: CSSProperties = {
   padding: '1.5rem',
@@ -44,8 +41,7 @@ export default function ReviewPage(): JSX.Element {
       <header style={{ display: 'grid', gap: '0.5rem' }}>
         <h1>Review og download</h1>
         <p style={{ maxWidth: '48rem' }}>
-          Et overblik over beregningerne for modul B1. Eksporter rapporten som PDF for at dele den med
-          resten af organisationen.
+          Et overblik over beregningerne for modul B1. Eksporter rapporten som PDF for at dele den med resten af organisationen.
         </p>
       </header>
 
@@ -86,7 +82,7 @@ function ResultCard({ entry }: { entry: CalculatedModuleResult }): JSX.Element {
       <header style={{ display: 'grid', gap: '0.5rem' }}>
         <h2 style={{ margin: 0 }}>{entry.title}</h2>
         <p style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600 }}>
-          {result.value} {result.unit ?? ''}
+          {result.value} {result.unit}
         </p>
       </header>
       <div>
@@ -129,23 +125,5 @@ function EmptyCard(): JSX.Element {
         Når du udfylder modul B1 i wizardens første trin, vises resultatet her.
       </p>
     </section>
-export default function ReviewPage(): JSX.Element {
-  const { results } = useLiveResults()
-
-  const handleDownload = async (): Promise<void> => {
-    await downloadReport(results)
-  }
-
-  return (
-    <main style={{ padding: '2rem' }}>
-      <h1>Review og download</h1>
-      <pre>{JSON.stringify(results, null, 2)}</pre>
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <PrimaryButton onClick={handleDownload}>Download PDF</PrimaryButton>
-        <PrimaryButton as={Link} href="/wizard">
-          Tilbage til wizard
-        </PrimaryButton>
-      </div>
-    </main>
   )
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,6 +2,7 @@
  * Landing page der leder brugeren ind i beregningsflowet.
  */
 import Link from 'next/link'
+
 import { PrimaryButton } from '../components/ui/PrimaryButton'
 
 export default function HomePage(): JSX.Element {

--- a/apps/web/features/pdf/ReportPreviewClient.tsx
+++ b/apps/web/features/pdf/ReportPreviewClient.tsx
@@ -1,15 +1,11 @@
 /**
- * Klientkomponent der viser PDF-preview via dynamic import.
+ * Klientkomponent der renderer PDF-preview for beregnede moduler.
  */
 'use client'
-
 
 import { useMemo } from 'react'
 import dynamic from 'next/dynamic'
 import type { CalculatedModuleResult } from '@org/shared'
-import dynamic from 'next/dynamic'
-import type { ModuleResult } from '@org/shared'
-
 
 const PDFViewer = dynamic(() => import('@react-pdf/renderer').then((mod) => mod.PDFViewer), {
   ssr: false
@@ -17,7 +13,6 @@ const PDFViewer = dynamic(() => import('@react-pdf/renderer').then((mod) => mod.
 const DocumentComponent = dynamic(() => import('@org/shared').then((mod) => mod.EsgReportPdf), {
   ssr: false
 })
-
 
 export default function ReportPreviewClient({
   results
@@ -30,15 +25,12 @@ export default function ReportPreviewClient({
   )
 
   if (!printable.length) {
-export default function ReportPreviewClient({ results }: { results: ModuleResult[] }): JSX.Element {
-  if (!results.length) {
     return <p>Ingen resultater at vise endnu.</p>
   }
 
   return (
     <PDFViewer style={{ width: '100%', height: '80vh' }}>
       <DocumentComponent results={printable} />
-      <DocumentComponent results={results} />
     </PDFViewer>
   )
 }

--- a/apps/web/features/pdf/downloadClient.tsx
+++ b/apps/web/features/pdf/downloadClient.tsx
@@ -14,10 +14,7 @@ export async function downloadReport(results: CalculatedModuleResult[]): Promise
     console.warn('Ingen beregninger til PDF-download endnu.')
     return
   }
-  const blob = await pdf(<EsgReportPdf results={printable} />).toBlob()
-import type { ModuleResult } from '@org/shared'
 
-export async function downloadReport(results: ModuleResult[]): Promise<void> {
-  const blob = await pdf(<EsgReportPdf results={results} />).toBlob()
+  const blob = await pdf(<EsgReportPdf results={printable} />).toBlob()
   saveAs(blob, 'esg-rapport.pdf')
 }

--- a/apps/web/features/results/useLiveResults.ts
+++ b/apps/web/features/results/useLiveResults.ts
@@ -25,11 +25,4 @@ export function useLiveResults(): { results: CalculatedModuleResult[] } {
 
     return { results: sorted }
   }, [state])
-import type { ModuleResult } from '@org/shared'
-import { useWizard } from '../wizard/useWizard'
-
-export function useLiveResults(): { results: ModuleResult[] } {
-  const { state } = useWizard()
-
-  return useMemo(() => ({ results: aggregateResults(state) }), [state])
 }

--- a/apps/web/features/wizard/steps/B1.tsx
+++ b/apps/web/features/wizard/steps/B1.tsx
@@ -144,6 +144,3 @@ export function B1Step({ state, onChange }: WizardStepProps): JSX.Element {
     </form>
   )
 }
-import { createWizardStep } from './StepTemplate'
-
-export const B1Step = createWizardStep('B1', 'Modul B1')

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -33,7 +33,6 @@ export type WizardStep = {
 
 export const wizardSteps: WizardStep[] = [
   { id: 'B1', label: 'B1 – Scope 2 elforbrug', component: B1Step },
-  { id: 'B1', label: 'Modul B1', component: B1Step },
   { id: 'B2', label: 'Modul B2', component: B2Step },
   { id: 'B3', label: 'Modul B3', component: B3Step },
   { id: 'B4', label: 'Modul B4', component: B4Step },

--- a/apps/web/features/wizard/useWizard.ts
+++ b/apps/web/features/wizard/useWizard.ts
@@ -10,7 +10,6 @@ import { loadWizardState, persistWizardState } from '../../lib/storage/localStor
 import { wizardSteps } from './steps'
 
 export type WizardState = ModuleInput
-export type WizardState = Record<string, unknown>
 
 type WizardHook = {
   currentStep: number

--- a/apps/web/lib/storage/localStorage.ts
+++ b/apps/web/lib/storage/localStorage.ts
@@ -8,17 +8,12 @@ import type { ModuleInput } from '@org/shared'
 const STORAGE_KEY = 'esg-wizard-state'
 
 export function loadWizardState(): ModuleInput {
-
-const STORAGE_KEY = 'esg-wizard-state'
-
-export function loadWizardState(): Record<string, unknown> {
   if (typeof window === 'undefined') {
     return {}
   }
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     return raw ? (JSON.parse(raw) as ModuleInput) : {}
-    return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
   } catch (error) {
     console.warn('Kunne ikke læse wizard-state', error)
     return {}
@@ -26,7 +21,6 @@ export function loadWizardState(): Record<string, unknown> {
 }
 
 export function persistWizardState(state: ModuleInput): void {
-export function persistWizardState(state: Record<string, unknown>): void {
   if (typeof window === 'undefined') {
     return
   }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
-// NOTE: Denne fil må ikke redigeres manuelt.
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,9 +1,8 @@
 /**
- * Next.js konfiguration for webappen med streng typed import.
+ * Next.js konfiguration for webappen.
+ * @type {import('next').NextConfig}
  */
-import type { NextConfig } from 'next'
-
-const config: NextConfig = {
+const config = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,8 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@org/eslint-config": "workspace:*",
+    "@org/tsconfig": "workspace:*",
     "@playwright/test": "^1.55.1",
     "@testing-library/jest-dom": "^6.4.5",
     "@types/file-saver": "^2.0.7",
@@ -26,9 +28,11 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-unused-imports": "^3.1.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",
-    "@testing-library/jest-dom": "^6.4.5",
     "jsdom": "^24.1.0",
     "typescript": "^5.6.2",
     "vitest": "^2.0.5"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,12 +1,34 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "@org/tsconfig/base",
   "compilerOptions": {
     "jsx": "preserve",
     "moduleResolution": "Bundler",
     "allowJs": false,
     "noEmit": true,
-    "types": ["node", "vitest/globals"]
+    "types": [
+      "node",
+      "vitest/globals"
+    ],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "incremental": true,
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docs/adr/0001-config-foundations.md
+++ b/docs/adr/0001-config-foundations.md
@@ -1,0 +1,22 @@
+# ADR 0001: Introduce shared configuration packages
+
+- Status: Accepted
+- Date: 2025-02-XX
+
+## Context
+Linting, formatting and TypeScript settings diverged between applications and packages. Each workspace defined toolchains independently, leading to duplicated effort and drift (for example, multiple tsconfig variants and ad-hoc ESLint setups).
+
+## Decision
+Create internal configuration packages under `packages/config/*`:
+
+- `@org/tsconfig` – exports the current base compiler settings.
+- `@org/eslint-config` – provides a base TypeScript preset and a Next.js variant.
+- `@org/prettier-config` – supplies a repository-wide formatting profile.
+- `@org/jest-config` – placeholder for unified test configuration once Jest is required.
+
+Packages and the Next.js app now extend these shared configs. Root tooling (Prettier) consumes the same source of truth.
+
+## Consequences
+- Centralised defaults enable consistent upgrades and future strictness changes.
+- Individual packages can still layer additional options locally.
+- Further work will align lint/typecheck pipelines with the new presets and tighten rules.

--- a/docs/adr/0002-quality-gates.md
+++ b/docs/adr/0002-quality-gates.md
@@ -1,0 +1,21 @@
+# ADR 0002: Enforce shared quality gates
+
+- Status: Accepted
+- Date: 2025-02-XX
+
+## Context
+
+Linting, type-checking, tests og build kørte kun vejledende i CI. Jobs var markeret med `continue-on-error`, og reglerne i den delte ESLint-konfiguration fangede ikke ubrugte imports eller inkonsistente importsorteringer. TypeScript-basen manglede flere strict-flag, hvilket kunne skjule fejl ved optional properties og indeksopslag.
+
+## Decision
+
+- Skærp `@org/tsconfig` med `moduleDetection`, `exactOptionalPropertyTypes`, `noImplicitOverride`, `noUncheckedIndexedAccess` og beslægtede strict-flags.
+- Udvid `@org/eslint-config` til at håndhæve konsistente type-imports, importorden og automatisk fjerne ubrugte imports via `eslint-plugin-import` og `eslint-plugin-unused-imports`.
+- Tilføj `format`-scripts og dokumentér lokale kvalitetskontroller i README.
+- Omstrukturér CI-workflowet til et matrix-job uden `continue-on-error`, så lint, typecheck, test og build blokerer pull requests.
+
+## Consequences
+
+- Udviklere får tidlige signaler når imports er overflødige, eller når indeksopslag kan returnere `undefined`.
+- CI-fejl er nu blokkerende, hvilket øger tilliden til main-branchens kvalitet.
+- Nye lint-regler kan kræve små kodeoprydninger når moduler redigeres; standarden er nu dokumenteret og konsistent i hele monorepoet.

--- a/docs/quality/baseline.md
+++ b/docs/quality/baseline.md
@@ -1,0 +1,21 @@
+# Baseline – February 2025
+
+## Installation
+- `pnpm install` succeeds with warnings about missing `GITHUB_TOKEN` and a broken lockfile that contains duplicated mapping keys for `next`. Install pulls ~540 packages and completes in ~50s.
+
+## Lint
+- `pnpm -w run lint` fails because `apps/web` relies on `next lint` with a `next.config.ts` file. Next 14.2.5 aborts linting when configuration is not provided via `.js` or `.mjs`.
+
+## Typecheck
+- `pnpm -w run typecheck` fails in `packages/tooling` due to merge artefacts inside `src/csv-to-schema.ts` that break TypeScript parsing.
+
+## Tests
+- `pnpm -w run test` fails in `packages/shared`. The Vitest suite cannot parse `calculations/__tests__/runModule.spec.ts` because duplicated comments/imports left from a merge introduce stray text.
+
+## Build
+- `pnpm -w run build` fails for the same `packages/tooling` TypeScript errors seen during typechecking.
+
+## Notable Risks
+- Repository lockfile is invalid, preventing deterministic installs.
+- `.npmrc` enforces a GitHub token for all commands, spamming local workflows.
+- Duplicate dependency keys exist in `apps/web/package.json`, causing Vite warnings during tests.

--- a/docs/runbooks/publishing.md
+++ b/docs/runbooks/publishing.md
@@ -1,0 +1,45 @@
+# Publish runbook
+
+Denne runbook beskriver hvordan vi udgiver pakker til GitHub Packages uden at lække tokens i lokale opsætninger.
+
+## Oversigt
+
+- GitHub Actions workflowet [`Publish`](../../.github/workflows/publish.yml) kører lint, test og build før udgivelse.
+- Workflowet opretter en midlertidig `~/.npmrc`, så adgangstoken kun lever i CI.
+- Lokale udviklere behøver ingen GitHub token for almindeligt arbejde og bør kun konfigurere en personlig `~/.npmrc`, når de skal udgive.
+
+## Forudsætninger
+
+- GitHub personal access token med scope `write:packages`.
+- `corepack` aktiveret (kræves for pnpm) og pnpm versionen i `packageManager`.
+
+## Publicering fra lokal maskine
+
+1. Log ind i GitHub og opret et PAT med mindst `write:packages`.
+2. Eksporter tokenet midlertidigt:
+   ```bash
+   export NODE_AUTH_TOKEN=ghp_xxx
+   ```
+3. Skriv en midlertidig `~/.npmrc`:
+   ```bash
+   cat <<'RC' > ~/.npmrc
+   @org:registry=https://npm.pkg.github.com
+   //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+   always-auth=true
+   RC
+   ```
+4. Kør kvalitetskontrollerne: `pnpm -w run lint && pnpm -w run typecheck && pnpm -w run test && pnpm -w run build`.
+5. Udgiv: `pnpm -r publish --access restricted`.
+6. Fjern tokenet fra miljøet og slet `~/.npmrc`, hvis det kun var til midlertidigt brug.
+
+## CI workflow
+
+- Workflowet opretter den samme `~/.npmrc` på farten med `${{ secrets.GITHUB_TOKEN }}`.
+- Tokenet gives til `pnpm -r publish` via `NODE_AUTH_TOKEN` og findes ikke i repoet.
+- Hvis publiceringen fejler, rotation af tokenet er kun påkrævet i GitHub secrets.
+
+## Fejlfinding
+
+- **`Failed to replace env in config: ${NODE_AUTH_TOKEN}`:** Tokenet er ikke sat. Eksporter det eller kør via workflowet.
+- **`403 Forbidden` under publish:** Kontroller at PAT har `write:packages` og at pakken hedder `@org/*`.
+- **`pnpm` beder om login under install:** Sørg for at `~/.npmrc` er fjernet; lokale installs skal ikke bruge auth.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "typecheck": "turbo run typecheck"
+    "typecheck": "turbo run typecheck",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
   },
   "devDependencies": {
+    "@org/eslint-config": "workspace:*",
+    "@org/prettier-config": "workspace:*",
+    "@org/tsconfig": "workspace:*",
     "@types/node": "^20.11.30",
     "playwright": "^1.48.0",
     "turbo": "^2.1.1",

--- a/packages/config/eslint-config/base.js
+++ b/packages/config/eslint-config/base.js
@@ -1,0 +1,66 @@
+const path = require('node:path')
+
+module.exports = {
+  root: false,
+  env: {
+    es2022: true,
+    node: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint', 'import', 'unused-imports'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript'
+  ],
+  settings: {
+    'import/resolver': {
+      typescript: {
+        alwaysTryTypes: true,
+        project: path.resolve(__dirname, '../../../../tsconfig.base.json')
+      }
+    }
+  },
+  rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        disallowTypeAnnotations: false,
+        fixStyle: 'inline-type-imports'
+      }
+    ],
+    '@typescript-eslint/no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'warn',
+      {
+        vars: 'all',
+        varsIgnorePattern: '^_',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+        ignoreRestSiblings: true
+      }
+    ],
+    'import/no-duplicates': ['error', { considerQueryString: true }],
+    'import/newline-after-import': ['error', { count: 1 }],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index'], 'type'],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true
+        },
+        'newlines-between': 'always'
+      }
+    ],
+    'object-shorthand': ['error', 'always'],
+    'prefer-const': ['error', { destructuring: 'all', ignoreReadBeforeAssign: true }]
+  }
+}

--- a/packages/config/eslint-config/next.js
+++ b/packages/config/eslint-config/next.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next/core-web-vitals', require.resolve('./base')]
+}

--- a/packages/config/eslint-config/package.json
+++ b/packages/config/eslint-config/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@org/eslint-config",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "files": ["base.js", "next.js"],
+  "exports": {
+    "./base": "./base.js",
+    "./next": "./next.js"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.0"
+  },
+  "dependencies": {
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-unused-imports": "^3.1.0"
+  }
+}

--- a/packages/config/jest-config/index.cjs
+++ b/packages/config/jest-config/index.cjs
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/config/jest-config/package.json
+++ b/packages/config/jest-config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@org/jest-config",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "index.cjs",
+  "files": ["index.cjs"]
+}

--- a/packages/config/prettier-config/index.cjs
+++ b/packages/config/prettier-config/index.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  arrowParens: 'avoid',
+  singleQuote: true,
+  semi: false,
+  trailingComma: 'all',
+  printWidth: 100,
+  tabWidth: 2
+}

--- a/packages/config/prettier-config/package.json
+++ b/packages/config/prettier-config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@org/prettier-config",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "index.cjs",
+  "files": ["index.cjs"]
+}

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "moduleDetection": "force",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": "."
+  }
+}

--- a/packages/config/tsconfig/package.json
+++ b/packages/config/tsconfig/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@org/tsconfig",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "files": ["base.json"],
+  "exports": {
+    "./base": "./base.json"
+  }
+}

--- a/packages/shared/.eslintrc.json
+++ b/packages/shared/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@org/eslint-config/base"]
+}

--- a/packages/shared/calculations/__tests__/__snapshots__/runModule.spec.ts.snap
+++ b/packages/shared/calculations/__tests__/__snapshots__/runModule.spec.ts.snap
@@ -1,14 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`createDefaultResult > returnerer forventet basisstruktur for andre moduler 1`] = `
-exports[`createDefaultResult > returnerer forventet stubstruktur 1`] = `
 {
   "assumptions": [
     "Standardfaktor: 1",
   ],
   "trace": [
     "Input(B2)=42",
-    "Input(B1)=42",
   ],
   "unit": "point",
   "value": 42,

--- a/packages/shared/calculations/__tests__/runModule.spec.ts
+++ b/packages/shared/calculations/__tests__/runModule.spec.ts
@@ -52,14 +52,3 @@ describe('runB1', () => {
     ])
   })
 })
- * Snapshot-test der verificerer standardresultatet for modulberegninger.
- */
-import { describe, expect, it } from 'vitest'
-import { createDefaultResult } from '../runModule'
-
-describe('createDefaultResult', () => {
-  it('returnerer forventet stubstruktur', () => {
-    const result = createDefaultResult('B1', { B1: 42 })
-    expect(result).toMatchSnapshot()
-  })
-})

--- a/packages/shared/calculations/factors.ts
+++ b/packages/shared/calculations/factors.ts
@@ -12,7 +12,3 @@ export const factors = {
     unit: 't CO2e'
   }
 } as const
-
-export const factors: Record<string, number> = {
-  defaultFactor: 1
-}

--- a/packages/shared/calculations/modules/runB1.ts
+++ b/packages/shared/calculations/modules/runB1.ts
@@ -113,17 +113,4 @@ function toSharePercent(
     return factors.b1.maximumRenewableSharePercent
   }
   return value
- * Beregning for modul B1 med deterministisk stub.
- */
-import type { ModuleInput, ModuleResult } from '../../types'
-import { createDefaultResult } from '../runModule'
-
-export function runB1(input: ModuleInput): ModuleResult {
-  const result = createDefaultResult('B1', input)
-  return {
-    ...result,
-    trace: [...result.trace, 'runB1'],
-    assumptions: [...result.assumptions, 'Stubberegning'],
-    warnings: result.warnings
-  }
 }

--- a/packages/shared/calculations/runModule.ts
+++ b/packages/shared/calculations/runModule.ts
@@ -9,7 +9,6 @@ import {
   type ModuleInput,
   type ModuleResult
 } from '../types'
-import type { ModuleCalculator, ModuleInput, ModuleResult } from '../types'
 import { factors } from './factors'
 import { runB1 } from './modules/runB1'
 import { runB2 } from './modules/runB2'
@@ -56,7 +55,6 @@ const moduleTitles: Record<ModuleId, string> = {
 }
 
 export const moduleCalculators: Record<ModuleId, ModuleCalculator> = {
-export const moduleCalculators: Record<string, ModuleCalculator> = {
   B1: runB1,
   B2: runB2,
   B3: runB3,
@@ -80,8 +78,6 @@ export const moduleCalculators: Record<string, ModuleCalculator> = {
 }
 
 export function createDefaultResult(moduleId: ModuleId, input: ModuleInput): ModuleResult {
-export type ModuleId = keyof typeof moduleCalculators
-export function createDefaultResult(moduleId: string, input: ModuleInput): ModuleResult {
   const rawValue = input[moduleId]
   const numericValue = typeof rawValue === 'number' ? rawValue : Number(rawValue ?? 0)
 
@@ -105,8 +101,4 @@ export function aggregateResults(input: ModuleInput): CalculatedModuleResult[] {
     title: moduleTitles[moduleId],
     result: runModule(moduleId, input)
   }))
-export function aggregateResults(input: ModuleInput): ModuleResult[] {
-  return (Object.keys(moduleCalculators) as ModuleId[]).map((moduleId) =>
-    runModule(moduleId, input)
-  )
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,10 +22,15 @@
     "react": "^18.0.0"
   },
   "devDependencies": {
+    "@org/eslint-config": "workspace:*",
+    "@org/tsconfig": "workspace:*",
     "@types/node": "^20.11.30",
     "@types/react": "^18.3.5",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-unused-imports": "^3.1.0",
     "eslint": "^8.57.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/shared/pdf/EsgReportPdf.tsx
+++ b/packages/shared/pdf/EsgReportPdf.tsx
@@ -3,7 +3,6 @@
  */
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
 import type { CalculatedModuleResult } from '../types'
-import type { ModuleResult } from '../types'
 
 const styles = StyleSheet.create({
   page: { padding: 32 },
@@ -17,12 +16,8 @@ const styles = StyleSheet.create({
 })
 
 export function EsgReportPdf({ results }: { results: CalculatedModuleResult[] }): JSX.Element {
-  const sections = results.length ? results : []
+  const sections = results.length > 0 ? results : []
 
-  row: { marginBottom: 8 }
-})
-
-export function EsgReportPdf({ results }: { results: ModuleResult[] }): JSX.Element {
   return (
     <Document>
       <Page size="A4" style={styles.page}>
@@ -34,16 +29,13 @@ export function EsgReportPdf({ results }: { results: ModuleResult[] }): JSX.Elem
             <View key={entry.moduleId} style={styles.module}>
               <Text style={styles.moduleTitle}>{entry.title}</Text>
               <Text style={styles.metric}>
-                Nettoresultat: {String(entry.result.value)} {entry.result.unit ?? ''}
+                Nettoresultat: {String(entry.result.value)} {entry.result.unit}
               </Text>
               {entry.result.warnings.length > 0 && (
                 <View>
                   <Text style={styles.label}>Advarsler</Text>
                   {entry.result.warnings.map((warning, index) => (
-                    <Text
-                      key={`${entry.moduleId}-warning-${index}`}
-                      style={styles.listItem}
-                    >
+                    <Text key={`${entry.moduleId}-warning-${index}`} style={styles.listItem}>
                       • {warning}
                     </Text>
                   ))}
@@ -52,10 +44,7 @@ export function EsgReportPdf({ results }: { results: ModuleResult[] }): JSX.Elem
               <View>
                 <Text style={styles.label}>Antagelser</Text>
                 {entry.result.assumptions.map((assumption, index) => (
-                  <Text
-                    key={`${entry.moduleId}-assumption-${index}`}
-                    style={styles.listItem}
-                  >
+                  <Text key={`${entry.moduleId}-assumption-${index}`} style={styles.listItem}>
                     • {assumption}
                   </Text>
                 ))}
@@ -71,13 +60,6 @@ export function EsgReportPdf({ results }: { results: ModuleResult[] }): JSX.Elem
             </View>
           ))
         )}
-        <View>
-          {results.map((result, index) => (
-            <Text key={index} style={styles.row}>
-              Resultat {index + 1}: {String(result.value)} {result.unit ?? ''}
-            </Text>
-          ))}
-        </View>
       </Page>
     </Document>
   )

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -16,14 +16,9 @@ export type B1Input = z.infer<typeof b1InputSchema>
 
 export const esgInputSchema = z
   .object({
-    B1: b1InputSchema.optional(),
-    B2: z.string().optional()
+    B1: b1InputSchema.optional()
   })
   .passthrough()
-export const esgInputSchema = z.object({
-  B1: z.string().optional(),
-  B2: z.string().optional()
-}).passthrough()
 
 export type EsgInput = z.infer<typeof esgInputSchema>
 

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "@org/tsconfig/base",
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -28,18 +28,15 @@ export const moduleIds = [
 
 export type ModuleId = (typeof moduleIds)[number]
 
-export type ModuleInput = {
-  B1?: B1Input
-  [key: string]: unknown
+type ModuleInputBase = Partial<Record<ModuleId, unknown>> & {
+  B1?: B1Input | null | undefined
 }
 
- * Fælles typer for input, moduler og PDF.
- */
-export type ModuleInput = Record<string, unknown>
+export type ModuleInput = ModuleInputBase & Record<string, unknown>
 
 export type ModuleResult = {
-  value: number | string
-  unit?: string
+  value: number
+  unit: string
   assumptions: string[]
   trace: string[]
   warnings: string[]

--- a/packages/tooling/.eslintrc.json
+++ b/packages/tooling/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@org/eslint-config/base"]
+}

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -17,12 +17,17 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@org/eslint-config": "workspace:*",
+    "@org/tsconfig": "workspace:*",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-unused-imports": "^3.1.0",
+    "eslint": "^8.57.0",
     "tsx": "^4.15.7",
     "typescript": "^5.6.2",
-    "vitest": "^2.0.5",
-    "@types/node": "^20.11.30",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0"
+    "vitest": "^2.0.5"
   }
 }

--- a/packages/tooling/src/csv-to-schema.ts
+++ b/packages/tooling/src/csv-to-schema.ts
@@ -41,9 +41,6 @@ const typeMap: Record<string, unknown> = {
 
 const moduleOverrides: Record<string, unknown> = {
   B1: b1Override
-const typeMap: Record<string, unknown> = {
-  string: { type: 'string' },
-  number: { type: 'number' }
 }
 
 export async function convertCsvToSchema(csvPath: string): Promise<Record<string, unknown>> {
@@ -56,11 +53,13 @@ export async function convertCsvToSchema(csvPath: string): Promise<Record<string
     if (!module) {
       return acc
     }
-    if (moduleOverrides[module]) {
-      acc[module] = moduleOverrides[module]
+    const override = moduleOverrides[module]
+    if (override) {
+      acc[module] = override
       return acc
     }
-    acc[module] = typeMap[valueType] ?? { type: 'string' }
+    const mappedType = typeMap[valueType ?? '']
+    acc[module] = mappedType ?? { type: 'string' }
     return acc
   }, {})
 

--- a/packages/tooling/tsconfig.json
+++ b/packages/tooling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "@org/tsconfig/base",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@org/eslint-config':
+        specifier: workspace:*
+        version: link:packages/config/eslint-config
+      '@org/prettier-config':
+        specifier: workspace:*
+        version: link:packages/config/prettier-config
+      '@org/tsconfig':
+        specifier: workspace:*
+        version: link:packages/config/tsconfig
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.17
@@ -38,7 +47,6 @@ importers:
       next:
         specifier: 14.2.5
         version: 14.2.5(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-        version: 14.2.5(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -46,6 +54,12 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@org/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/config/eslint-config
+      '@org/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/config/tsconfig
       '@playwright/test':
         specifier: ^1.55.1
         version: 1.55.1
@@ -55,9 +69,6 @@ importers:
       '@types/file-saver':
         specifier: ^2.0.7
         version: 2.0.7
-      '@testing-library/jest-dom':
-        specifier: ^6.4.5
-        version: 6.8.0
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.17
@@ -76,6 +87,15 @@ importers:
       eslint-config-next:
         specifier: 14.2.5
         version: 14.2.5(eslint@8.57.1)(typescript@5.9.2)
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-unused-imports:
+        specifier: ^3.1.0
+        version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
@@ -86,6 +106,33 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
 
+  packages/config/eslint-config:
+    dependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.18.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^7.18.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-unused-imports:
+        specifier: ^3.1.0
+        version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
+
+  packages/config/jest-config: {}
+
+  packages/config/prettier-config: {}
+
+  packages/config/tsconfig: {}
+
   packages/shared:
     dependencies:
       '@react-pdf/renderer':
@@ -95,6 +142,12 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@org/eslint-config':
+        specifier: workspace:*
+        version: link:../config/eslint-config
+      '@org/tsconfig':
+        specifier: workspace:*
+        version: link:../config/tsconfig
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.17
@@ -110,6 +163,15 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-unused-imports:
+        specifier: ^3.1.0
+        version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -125,6 +187,12 @@ importers:
 
   packages/tooling:
     devDependencies:
+      '@org/eslint-config':
+        specifier: workspace:*
+        version: link:../config/eslint-config
+      '@org/tsconfig':
+        specifier: workspace:*
+        version: link:../config/tsconfig
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.17
@@ -137,6 +205,15 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-unused-imports:
+        specifier: ^3.1.0
+        version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
       tsx:
         specifier: ^4.15.7
         version: 4.20.6
@@ -1614,6 +1691,20 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-unused-imports@3.2.0:
+    resolution: {integrity: sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': 6 - 7
+      eslint: '8'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+
+  eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -4396,8 +4487,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4416,7 +4507,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4427,22 +4518,33 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4453,7 +4555,36 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4515,6 +4646,15 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+      eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+
+  eslint-rule-composer@0.3.0: {}
 
   eslint-scope@7.2.2:
     dependencies:
@@ -5127,7 +5267,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   next@14.2.5(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-  next@14.2.5(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - apps/*
   - packages/*
+  - packages/config/*
   - tooling

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@org/prettier-config')

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,13 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ES2021",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "baseUrl": "."
-  }
+  "extends": "./packages/config/tsconfig/base.json"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "tasks": {
     "lint": { "outputs": [] },
     "typecheck": { "outputs": [] },
-    "test": { "outputs": ["coverage/**"] },
+    "test": { "outputs": [] },
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**"] }
   }
 }


### PR DESCRIPTION
## Summary
- remove the repository-level .npmrc so routine installs no longer require a GitHub token
- teach the Publish workflow to generate an ephemeral ~/.npmrc in CI before running pnpm publish
- document the publishing procedure in a runbook and surface it from the README/CHANGELOG

## Testing
- pnpm -w run lint
- pnpm -w run typecheck
- pnpm -w run test
- pnpm -w run build

------
https://chatgpt.com/codex/tasks/task_e_68d6f3ef830083259e74f3b6bed18e28