### PR TITLE
Fix duplicated imports and clean shared configs

### DIFF
--- a/apps/web/app/(review)/review/page.tsx
+++ b/apps/web/app/(review)/review/page.tsx
@@ -5,16 +5,13 @@
 
 import Link from 'next/link'
 import { useMemo, type CSSProperties } from 'react'
-import { useMemo, type CSSProperties } from 'react'
-import Link from 'next/link'
-import type { CalculatedModuleResult } from '@org/shared'
-import { useLiveResults } from '../../../features/results/useLiveResults'
-import { downloadReport } from '../../../features/pdf/downloadClient'
+
 import { PrimaryButton } from '../../../components/ui/PrimaryButton'
 import { downloadReport } from '../../../features/pdf/downloadClient'
 import { useLiveResults } from '../../../features/results/useLiveResults'
 
 import type { CalculatedModuleResult } from '@org/shared'
+
 const cardStyle: CSSProperties = {
   padding: '1.5rem',
   borderRadius: '0.75rem',

--- a/packages/config/eslint-config/base.js
+++ b/packages/config/eslint-config/base.js
@@ -4,10 +4,6 @@ module.exports = {
   root: false,
   env: {
     es2022: true,
-module.exports = {
-  root: false,
-  env: {
-    es2021: true,
     node: true
   },
   parser: '@typescript-eslint/parser',
@@ -67,6 +63,4 @@ module.exports = {
     'object-shorthand': ['error', 'always'],
     'prefer-const': ['error', { destructuring: 'all', ignoreReadBeforeAssign: true }]
   }
-  plugins: ['@typescript-eslint'],
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended']
 }

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -15,12 +15,6 @@
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
-    "target": "ES2021",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "baseUrl": "."


### PR DESCRIPTION
## Summary
- deduplicate and reorder imports in the review page to satisfy lint rules
- remove the duplicated export block from the shared ESLint base config
- drop repeated compiler options from the shared tsconfig base file

## Testing
- `pnpm -w run lint`
- `pnpm -w run typecheck`
- `pnpm -w run test`
- `pnpm -w run build`


------
https://chatgpt.com/codex/tasks/task_e_68d7f04ee0388325b4ec05e541a2e326