### PR TITLE
Add Scope 2 steam module B4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated TypeScript and ESLint configs to consume workspace presets.
 - ADR 0002 documenting the enforcement of strict lint/type settings and CI gates.
 - Publish runbook describing safe GitHub Packages authentication for releases.
+- Fuldt B4-modul for Scope 2 dampforbrug med schema, beregning, UI og tests.
 
 ### Changed
 - Replaced the Next.js TypeScript config with an `.mjs` variant to unblock `next lint` and let Next manage app compiler settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR 0002 documenting the enforcement of strict lint/type settings and CI gates.
 - Publish runbook describing safe GitHub Packages authentication for releases.
 - Fuldt B4-modul for Scope 2 dampforbrug med schema, beregning, UI og tests.
+- Fuldt B5-modul for øvrige Scope 2-energileverancer med schema, beregning, UI og tests.
 
 ### Changed
 - Replaced the Next.js TypeScript config with an `.mjs` variant to unblock `next lint` and let Next manage app compiler settings.

--- a/apps/web/app/(review)/review/page.tsx
+++ b/apps/web/app/(review)/review/page.tsx
@@ -29,7 +29,7 @@ export default function ReviewPage(): JSX.Element {
     [results]
   )
 
-  const primaryModuleIds = ['B1', 'B2', 'B3'] as const
+  const primaryModuleIds = ['B1', 'B2', 'B3', 'B4'] as const
   type PrimaryModuleId = (typeof primaryModuleIds)[number]
   const primaryResults = primaryModuleIds
     .map((moduleId) => printable.find((entry) => entry.moduleId === moduleId) ?? null)
@@ -136,7 +136,7 @@ function EmptyCard(): JSX.Element {
     <section style={{ ...cardStyle, background: '#f8faf9', borderStyle: 'dashed' }}>
       <h2 style={{ margin: 0 }}>Ingen data endnu</h2>
       <p style={{ margin: 0 }}>
-        Når du udfylder modulerne B1, B2 eller B3 i wizardens første trin, vises resultaterne her.
+        Når du udfylder modulerne B1, B2, B3 eller B4 i wizardens første trin, vises resultaterne her.
       </p>
     </section>
   )

--- a/apps/web/app/(review)/review/page.tsx
+++ b/apps/web/app/(review)/review/page.tsx
@@ -29,7 +29,7 @@ export default function ReviewPage(): JSX.Element {
     [results]
   )
 
-  const primaryModuleIds = ['B1', 'B2', 'B3', 'B4'] as const
+  const primaryModuleIds = ['B1', 'B2', 'B3', 'B4', 'B5'] as const
   type PrimaryModuleId = (typeof primaryModuleIds)[number]
   const primaryResults = primaryModuleIds
     .map((moduleId) => printable.find((entry) => entry.moduleId === moduleId) ?? null)
@@ -136,7 +136,7 @@ function EmptyCard(): JSX.Element {
     <section style={{ ...cardStyle, background: '#f8faf9', borderStyle: 'dashed' }}>
       <h2 style={{ margin: 0 }}>Ingen data endnu</h2>
       <p style={{ margin: 0 }}>
-        Når du udfylder modulerne B1, B2, B3 eller B4 i wizardens første trin, vises resultaterne her.
+        Når du udfylder modulerne B1, B2, B3, B4 eller B5 i wizardens første trin, vises resultaterne her.
       </p>
     </section>
   )

--- a/apps/web/features/results/useLiveResults.ts
+++ b/apps/web/features/results/useLiveResults.ts
@@ -13,7 +13,7 @@ export function useLiveResults(): { results: CalculatedModuleResult[] } {
 
   return useMemo(() => {
     const aggregated = aggregateResults(state)
-    const priorityOrder: Record<string, number> = { B1: 0, B2: 1, B3: 2, B4: 3 }
+    const priorityOrder: Record<string, number> = { B1: 0, B2: 1, B3: 2, B4: 3, B5: 4 }
     const sorted = [...aggregated].sort((a, b) => {
       const priorityA = priorityOrder[a.moduleId] ?? Number.POSITIVE_INFINITY
       const priorityB = priorityOrder[b.moduleId] ?? Number.POSITIVE_INFINITY

--- a/apps/web/features/results/useLiveResults.ts
+++ b/apps/web/features/results/useLiveResults.ts
@@ -13,7 +13,7 @@ export function useLiveResults(): { results: CalculatedModuleResult[] } {
 
   return useMemo(() => {
     const aggregated = aggregateResults(state)
-    const priorityOrder: Record<string, number> = { B1: 0, B2: 1, B3: 2 }
+    const priorityOrder: Record<string, number> = { B1: 0, B2: 1, B3: 2, B4: 3 }
     const sorted = [...aggregated].sort((a, b) => {
       const priorityA = priorityOrder[a.moduleId] ?? Number.POSITIVE_INFINITY
       const priorityB = priorityOrder[b.moduleId] ?? Number.POSITIVE_INFINITY

--- a/apps/web/features/wizard/steps/B4.tsx
+++ b/apps/web/features/wizard/steps/B4.tsx
@@ -3,6 +3,155 @@
  */
 'use client'
 
-import { createWizardStep } from './StepTemplate'
+import { useMemo } from 'react'
+import type { ChangeEvent } from 'react'
+import type { B4Input, ModuleInput, ModuleResult } from '@org/shared'
+import { runB4 } from '@org/shared'
+import type { WizardStepProps } from './StepTemplate'
 
-export const B4Step = createWizardStep('B4', 'Modul B4')
+type FieldKey = keyof B4Input
+
+type FieldConfig = {
+  key: FieldKey
+  label: string
+  description: string
+  unit: string
+  placeholder?: string
+}
+
+const FIELD_CONFIG: FieldConfig[] = [
+  {
+    key: 'steamConsumptionKwh',
+    label: 'Årligt dampforbrug',
+    description: 'Samlet dampenergi leveret fra forsyningen i kWh.',
+    unit: 'kWh'
+  },
+  {
+    key: 'recoveredSteamKwh',
+    label: 'Genindvundet damp eller kondensat',
+    description: 'Damp eller kondensat, der genanvendes og reducerer behovet.',
+    unit: 'kWh'
+  },
+  {
+    key: 'emissionFactorKgPerKwh',
+    label: 'Emissionsfaktor',
+    description: 'Kg CO2e pr. kWh i dampforsyningens miljødeklaration.',
+    unit: 'kg CO2e/kWh',
+    placeholder: '0.090'
+  },
+  {
+    key: 'renewableSharePercent',
+    label: 'Vedvarende andel',
+    description: 'Andel af dampen købt som certificeret vedvarende energi.',
+    unit: '%',
+    placeholder: '0-100'
+  }
+]
+
+const EMPTY_B4: B4Input = {
+  steamConsumptionKwh: null,
+  recoveredSteamKwh: null,
+  emissionFactorKgPerKwh: null,
+  renewableSharePercent: null
+}
+
+export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
+  const current = (state.B4 as B4Input | undefined) ?? EMPTY_B4
+
+  const preview = useMemo<ModuleResult>(() => {
+    return runB4({ B4: current } as ModuleInput)
+  }, [current])
+
+  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value.replace(',', '.')
+    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
+    const next: B4Input = {
+      ...current,
+      [field]: Number.isFinite(parsed) ? parsed : null
+    }
+    onChange('B4', next)
+  }
+
+  const hasData =
+    preview.trace.some((line) => line.includes('netSteamConsumptionKwh')) &&
+    (current.steamConsumptionKwh != null ||
+      current.recoveredSteamKwh != null ||
+      current.emissionFactorKgPerKwh != null ||
+      current.renewableSharePercent != null)
+
+  return (
+    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
+      <header style={{ display: 'grid', gap: '0.5rem' }}>
+        <h2>B4 – Scope 2 dampforbrug</h2>
+        <p>
+          Indtast data for organisationens indkøbte damp. Beregningen korrigerer for genanvendt damp og
+          dokumenteret vedvarende leverancer.
+        </p>
+      </header>
+      <section style={{ display: 'grid', gap: '1rem' }}>
+        {FIELD_CONFIG.map((field) => {
+          const value = current[field.key]
+          return (
+            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
+              <span style={{ fontWeight: 600 }}>
+                {field.label} ({field.unit})
+              </span>
+              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <input
+                type="number"
+                step="any"
+                value={value ?? ''}
+                placeholder={field.placeholder}
+                onChange={handleFieldChange(field.key)}
+                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                min={0}
+              />
+            </label>
+          )
+        })}
+      </section>
+      <section
+        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
+      >
+        <h3 style={{ margin: 0 }}>Estimat</h3>
+        {hasData ? (
+          <div style={{ display: 'grid', gap: '0.5rem' }}>
+            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+              {preview.value} {preview.unit}
+            </p>
+            <div>
+              <strong>Antagelser</strong>
+              <ul>
+                {preview.assumptions.map((assumption, index) => (
+                  <li key={index}>{assumption}</li>
+                ))}
+              </ul>
+            </div>
+            {preview.warnings.length > 0 && (
+              <div>
+                <strong>Advarsler</strong>
+                <ul>
+                  {preview.warnings.map((warning, index) => (
+                    <li key={index}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <details>
+              <summary>Teknisk trace</summary>
+              <ul>
+                {preview.trace.map((line, index) => (
+                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                    {line}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          </div>
+        ) : (
+          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
+        )}
+      </section>
+    </form>
+  )
+}

--- a/apps/web/features/wizard/steps/B5.tsx
+++ b/apps/web/features/wizard/steps/B5.tsx
@@ -3,6 +3,156 @@
  */
 'use client'
 
-import { createWizardStep } from './StepTemplate'
+import { useMemo, type ChangeEvent } from 'react'
 
-export const B5Step = createWizardStep('B5', 'Modul B5')
+import type { B5Input, ModuleInput, ModuleResult } from '@org/shared'
+import { runB5 } from '@org/shared'
+
+import type { WizardStepProps } from './StepTemplate'
+
+type FieldKey = keyof B5Input
+
+type FieldConfig = {
+  key: FieldKey
+  label: string
+  description: string
+  unit: string
+  placeholder?: string
+}
+
+const FIELD_CONFIG: FieldConfig[] = [
+  {
+    key: 'otherEnergyConsumptionKwh',
+    label: 'Årligt forbrug',
+    description: 'Samlet mængde indkøbt energi for den valgte leverance i kWh.',
+    unit: 'kWh'
+  },
+  {
+    key: 'recoveredEnergyKwh',
+    label: 'Genindvundet energi',
+    description: 'Energi der udnyttes fra processer eller genanvendelse og reducerer behovet.',
+    unit: 'kWh'
+  },
+  {
+    key: 'emissionFactorKgPerKwh',
+    label: 'Emissionsfaktor',
+    description: 'Kg CO2e pr. kWh ifølge leverandørens miljødeklaration.',
+    unit: 'kg CO2e/kWh',
+    placeholder: '0.075'
+  },
+  {
+    key: 'renewableSharePercent',
+    label: 'Vedvarende andel',
+    description: 'Andel dokumenteret som vedvarende energi for leverancen.',
+    unit: '%',
+    placeholder: '0-100'
+  }
+]
+
+const EMPTY_B5: B5Input = {
+  otherEnergyConsumptionKwh: null,
+  recoveredEnergyKwh: null,
+  emissionFactorKgPerKwh: null,
+  renewableSharePercent: null
+}
+
+export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
+  const current = (state.B5 as B5Input | undefined) ?? EMPTY_B5
+
+  const preview = useMemo<ModuleResult>(() => {
+    return runB5({ B5: current } as ModuleInput)
+  }, [current])
+
+  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value.replace(',', '.')
+    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
+    const next: B5Input = {
+      ...current,
+      [field]: Number.isFinite(parsed) ? parsed : null
+    }
+    onChange('B5', next)
+  }
+
+  const hasData =
+    preview.trace.some((line) => line.includes('netOtherEnergyConsumptionKwh')) &&
+    (current.otherEnergyConsumptionKwh != null ||
+      current.recoveredEnergyKwh != null ||
+      current.emissionFactorKgPerKwh != null ||
+      current.renewableSharePercent != null)
+
+  return (
+    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
+      <header style={{ display: 'grid', gap: '0.5rem' }}>
+        <h2>B5 – Scope 2 øvrige energileverancer</h2>
+        <p>
+          Indtast data for energileverancer som ikke dækkes af el, varme, køling eller damp. Beregningen korrigerer for
+          genindvundet energi og dokumenteret vedvarende andel.
+        </p>
+      </header>
+      <section style={{ display: 'grid', gap: '1rem' }}>
+        {FIELD_CONFIG.map((field) => {
+          const value = current[field.key]
+          return (
+            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
+              <span style={{ fontWeight: 600 }}>
+                {field.label} ({field.unit})
+              </span>
+              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <input
+                type="number"
+                step="any"
+                value={value ?? ''}
+                placeholder={field.placeholder}
+                onChange={handleFieldChange(field.key)}
+                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                min={0}
+              />
+            </label>
+          )
+        })}
+      </section>
+      <section
+        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
+      >
+        <h3 style={{ margin: 0 }}>Estimat</h3>
+        {hasData ? (
+          <div style={{ display: 'grid', gap: '0.5rem' }}>
+            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+              {preview.value} {preview.unit}
+            </p>
+            <div>
+              <strong>Antagelser</strong>
+              <ul>
+                {preview.assumptions.map((assumption, index) => (
+                  <li key={index}>{assumption}</li>
+                ))}
+              </ul>
+            </div>
+            {preview.warnings.length > 0 && (
+              <div>
+                <strong>Advarsler</strong>
+                <ul>
+                  {preview.warnings.map((warning, index) => (
+                    <li key={index}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <details>
+              <summary>Teknisk trace</summary>
+              <ul>
+                {preview.trace.map((line, index) => (
+                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                    {line}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          </div>
+        ) : (
+          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
+        )}
+      </section>
+    </form>
+  )
+}

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -35,7 +35,7 @@ export const wizardSteps: WizardStep[] = [
   { id: 'B1', label: 'B1 – Scope 2 elforbrug', component: B1Step },
   { id: 'B2', label: 'B2 – Scope 2 varmeforbrug', component: B2Step },
   { id: 'B3', label: 'B3 – Scope 2 køleforbrug', component: B3Step },
-  { id: 'B4', label: 'Modul B4', component: B4Step },
+  { id: 'B4', label: 'B4 – Scope 2 dampforbrug', component: B4Step },
   { id: 'B5', label: 'Modul B5', component: B5Step },
   { id: 'B6', label: 'Modul B6', component: B6Step },
   { id: 'B7', label: 'Modul B7', component: B7Step },

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -36,7 +36,7 @@ export const wizardSteps: WizardStep[] = [
   { id: 'B2', label: 'B2 – Scope 2 varmeforbrug', component: B2Step },
   { id: 'B3', label: 'B3 – Scope 2 køleforbrug', component: B3Step },
   { id: 'B4', label: 'B4 – Scope 2 dampforbrug', component: B4Step },
-  { id: 'B5', label: 'Modul B5', component: B5Step },
+  { id: 'B5', label: 'B5 – Scope 2 øvrige energileverancer', component: B5Step },
   { id: 'B6', label: 'Modul B6', component: B6Step },
   { id: 'B7', label: 'Modul B7', component: B7Step },
   { id: 'B8', label: 'Modul B8', component: B8Step },

--- a/packages/shared/calculations/__tests__/runModule.spec.ts
+++ b/packages/shared/calculations/__tests__/runModule.spec.ts
@@ -8,6 +8,7 @@ import { runB1 } from '../modules/runB1'
 import { runB2 } from '../modules/runB2'
 import { runB3 } from '../modules/runB3'
 import { runB4 } from '../modules/runB4'
+import { runB5 } from '../modules/runB5'
 import { factors } from '../factors'
 
 describe('createDefaultResult', () => {
@@ -175,6 +176,47 @@ describe('runB4', () => {
       'Feltet emissionFactorKgPerKwh kan ikke være negativt. 0 anvendes i stedet.',
       'Andelen af vedvarende energi er begrænset til 100%.',
       'Genindvundet damp overstiger det registrerede forbrug. Nettoforbruget sættes til 0.'
+    ])
+  })
+})
+
+describe('runB5', () => {
+  it('beregner nettoemission for øvrige energileverancer', () => {
+    const input: ModuleInput = {
+      B5: {
+        otherEnergyConsumptionKwh: 25_000,
+        recoveredEnergyKwh: 2_000,
+        emissionFactorKgPerKwh: 0.07,
+        renewableSharePercent: 35
+      }
+    }
+
+    const result = runB5(input)
+
+    expect(result.value).toBe(1.159)
+    expect(result.unit).toBe(factors.b5.unit)
+    expect(result.warnings).toEqual([])
+    expect(result.trace).toContain('netOtherEnergyConsumptionKwh=23000')
+  })
+
+  it('håndterer ugyldige værdier og capper vedvarende andel', () => {
+    const input: ModuleInput = {
+      B5: {
+        otherEnergyConsumptionKwh: 1_000,
+        recoveredEnergyKwh: 1_500,
+        emissionFactorKgPerKwh: -0.2,
+        renewableSharePercent: 140
+      }
+    }
+
+    const result = runB5(input)
+
+    expect(result.value).toBe(0)
+    expect(result.trace).toContain('emissionFactorKgPerKwh=0')
+    expect(result.warnings).toEqual([
+      'Feltet emissionFactorKgPerKwh kan ikke være negativt. 0 anvendes i stedet.',
+      'Andelen af vedvarende energi er begrænset til 100%.',
+      'Genindvundet energi overstiger det registrerede forbrug. Nettoforbruget sættes til 0.'
     ])
   })
 })

--- a/packages/shared/calculations/factors.ts
+++ b/packages/shared/calculations/factors.ts
@@ -37,5 +37,14 @@ export const factors = {
     recoveryCreditRate: 1,
     resultPrecision: 3,
     unit: 't CO2e'
+  },
+  b5: {
+    kgToTonnes: 0.001,
+    renewableMitigationRate: 0.8,
+    percentToRatio: 0.01,
+    maximumRenewableSharePercent: 100,
+    recoveryCreditRate: 1,
+    resultPrecision: 3,
+    unit: 't CO2e'
   }
 } as const

--- a/packages/shared/calculations/factors.ts
+++ b/packages/shared/calculations/factors.ts
@@ -28,5 +28,14 @@ export const factors = {
     recoveryCreditRate: 1,
     resultPrecision: 3,
     unit: 't CO2e'
+  },
+  b4: {
+    kgToTonnes: 0.001,
+    renewableMitigationRate: 0.85,
+    percentToRatio: 0.01,
+    maximumRenewableSharePercent: 100,
+    recoveryCreditRate: 1,
+    resultPrecision: 3,
+    unit: 't CO2e'
   }
 } as const

--- a/packages/shared/calculations/modules/runB4.ts
+++ b/packages/shared/calculations/modules/runB4.ts
@@ -1,15 +1,134 @@
 /**
- * Beregning for modul B4 med deterministisk stub.
+ * Beregning for modul B4 der vurderer nettoemissioner fra dampforbrug.
  */
-import type { ModuleInput, ModuleResult } from '../../types'
-import { createDefaultResult } from '../runModule'
+import type { B4Input, ModuleInput, ModuleResult } from '../../types'
+import { factors } from '../factors'
+
+type SanitisedB4 = Required<{
+  [Key in keyof B4Input]: number
+}>
 
 export function runB4(input: ModuleInput): ModuleResult {
-  const result = createDefaultResult('B4', input)
-  return {
-    ...result,
-    trace: [...result.trace, 'runB4'],
-    assumptions: [...result.assumptions, 'Stubberegning'],
-    warnings: result.warnings
+  const warnings: string[] = []
+  const assumptions = [
+    `Fradrag for genindvundet damp: ${Math.round(factors.b4.recoveryCreditRate * 100)}%`,
+    `Reduktion for vedvarende damp: ${Math.round(factors.b4.renewableMitigationRate * 100)}%`,
+    `Konvertering fra kg til ton: ${factors.b4.kgToTonnes}`
+  ]
+
+  const raw = (input.B4 ?? {}) as B4Input
+  const sanitised = normaliseInput(raw, warnings)
+
+  const adjustedSteamConsumptionKwh = Math.max(
+    0,
+    sanitised.steamConsumptionKwh - sanitised.recoveredSteamKwh * factors.b4.recoveryCreditRate
+  )
+
+  if (sanitised.recoveredSteamKwh > sanitised.steamConsumptionKwh) {
+    warnings.push('Genindvundet damp overstiger det registrerede forbrug. Nettoforbruget sættes til 0.')
   }
+
+  const grossEmissionsKg = adjustedSteamConsumptionKwh * sanitised.emissionFactorKgPerKwh
+  const renewableReductionKg =
+    grossEmissionsKg *
+    sanitised.renewableSharePercent *
+    factors.b4.percentToRatio *
+    factors.b4.renewableMitigationRate
+  const netEmissionsKg = Math.max(0, grossEmissionsKg - renewableReductionKg)
+  const netEmissionsTonnes = netEmissionsKg * factors.b4.kgToTonnes
+
+  const value = Number(netEmissionsTonnes.toFixed(factors.b4.resultPrecision))
+
+  return {
+    value,
+    unit: factors.b4.unit,
+    assumptions,
+    trace: [
+      `steamConsumptionKwh=${sanitised.steamConsumptionKwh}`,
+      `recoveredSteamKwh=${sanitised.recoveredSteamKwh}`,
+      `netSteamConsumptionKwh=${adjustedSteamConsumptionKwh}`,
+      `emissionFactorKgPerKwh=${sanitised.emissionFactorKgPerKwh}`,
+      `renewableSharePercent=${sanitised.renewableSharePercent}`,
+      `grossEmissionsKg=${grossEmissionsKg}`,
+      `renewableReductionKg=${renewableReductionKg}`,
+      `netEmissionsTonnes=${netEmissionsTonnes}`
+    ],
+    warnings
+  }
+}
+
+function normaliseInput(raw: B4Input, warnings: string[]): SanitisedB4 {
+  const hasAnyValue =
+    raw != null &&
+    Object.values(raw).some((value) => value != null && !Number.isNaN(Number(value)))
+
+  const safeSteamConsumption = toNonNegativeNumber(
+    raw?.steamConsumptionKwh,
+    'steamConsumptionKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeRecoveredSteam = toNonNegativeNumber(
+    raw?.recoveredSteamKwh,
+    'recoveredSteamKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeEmissionFactor = toNonNegativeNumber(
+    raw?.emissionFactorKgPerKwh,
+    'emissionFactorKgPerKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeShare = toSharePercent(raw?.renewableSharePercent, warnings, hasAnyValue)
+
+  return {
+    steamConsumptionKwh: safeSteamConsumption,
+    recoveredSteamKwh: safeRecoveredSteam,
+    emissionFactorKgPerKwh: safeEmissionFactor,
+    renewableSharePercent: safeShare
+  }
+}
+
+function toNonNegativeNumber(
+  value: number | null | undefined,
+  field: keyof B4Input,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push(`Feltet ${String(field)} mangler og behandles som 0.`)
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push(`Feltet ${String(field)} kan ikke være negativt. 0 anvendes i stedet.`)
+    return 0
+  }
+  return value
+}
+
+function toSharePercent(
+  value: number | null | undefined,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push('Andelen af vedvarende energi mangler og behandles som 0%.')
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push('Andelen af vedvarende energi kan ikke være negativ. 0% anvendes.')
+    return 0
+  }
+  if (value > factors.b4.maximumRenewableSharePercent) {
+    warnings.push(
+      `Andelen af vedvarende energi er begrænset til ${factors.b4.maximumRenewableSharePercent}%.`
+    )
+    return factors.b4.maximumRenewableSharePercent
+  }
+  return value
 }

--- a/packages/shared/calculations/modules/runB5.ts
+++ b/packages/shared/calculations/modules/runB5.ts
@@ -1,15 +1,134 @@
 /**
- * Beregning for modul B5 med deterministisk stub.
+ * Beregning for modul B5 der vurderer øvrige Scope 2-energileverancer.
  */
-import type { ModuleInput, ModuleResult } from '../../types'
-import { createDefaultResult } from '../runModule'
+import type { B5Input, ModuleInput, ModuleResult } from '../../types'
+import { factors } from '../factors'
+
+type SanitisedB5 = Required<{
+  [Key in keyof B5Input]: number
+}>
 
 export function runB5(input: ModuleInput): ModuleResult {
-  const result = createDefaultResult('B5', input)
-  return {
-    ...result,
-    trace: [...result.trace, 'runB5'],
-    assumptions: [...result.assumptions, 'Stubberegning'],
-    warnings: result.warnings
+  const warnings: string[] = []
+  const assumptions = [
+    `Fradrag for genindvundet energi: ${Math.round(factors.b5.recoveryCreditRate * 100)}%`,
+    `Reduktion for vedvarende energi: ${Math.round(factors.b5.renewableMitigationRate * 100)}%`,
+    `Konvertering fra kg til ton: ${factors.b5.kgToTonnes}`
+  ]
+
+  const raw = (input.B5 ?? {}) as B5Input
+  const sanitised = normaliseInput(raw, warnings)
+
+  const adjustedEnergyConsumptionKwh = Math.max(
+    0,
+    sanitised.otherEnergyConsumptionKwh - sanitised.recoveredEnergyKwh * factors.b5.recoveryCreditRate
+  )
+
+  if (sanitised.recoveredEnergyKwh > sanitised.otherEnergyConsumptionKwh) {
+    warnings.push('Genindvundet energi overstiger det registrerede forbrug. Nettoforbruget sættes til 0.')
   }
+
+  const grossEmissionsKg = adjustedEnergyConsumptionKwh * sanitised.emissionFactorKgPerKwh
+  const renewableReductionKg =
+    grossEmissionsKg *
+    sanitised.renewableSharePercent *
+    factors.b5.percentToRatio *
+    factors.b5.renewableMitigationRate
+  const netEmissionsKg = Math.max(0, grossEmissionsKg - renewableReductionKg)
+  const netEmissionsTonnes = netEmissionsKg * factors.b5.kgToTonnes
+
+  const value = Number(netEmissionsTonnes.toFixed(factors.b5.resultPrecision))
+
+  return {
+    value,
+    unit: factors.b5.unit,
+    assumptions,
+    trace: [
+      `otherEnergyConsumptionKwh=${sanitised.otherEnergyConsumptionKwh}`,
+      `recoveredEnergyKwh=${sanitised.recoveredEnergyKwh}`,
+      `netOtherEnergyConsumptionKwh=${adjustedEnergyConsumptionKwh}`,
+      `emissionFactorKgPerKwh=${sanitised.emissionFactorKgPerKwh}`,
+      `renewableSharePercent=${sanitised.renewableSharePercent}`,
+      `grossEmissionsKg=${grossEmissionsKg}`,
+      `renewableReductionKg=${renewableReductionKg}`,
+      `netEmissionsTonnes=${netEmissionsTonnes}`
+    ],
+    warnings
+  }
+}
+
+function normaliseInput(raw: B5Input, warnings: string[]): SanitisedB5 {
+  const hasAnyValue =
+    raw != null &&
+    Object.values(raw).some((value) => value != null && !Number.isNaN(Number(value)))
+
+  const safeEnergyConsumption = toNonNegativeNumber(
+    raw?.otherEnergyConsumptionKwh,
+    'otherEnergyConsumptionKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeRecoveredEnergy = toNonNegativeNumber(
+    raw?.recoveredEnergyKwh,
+    'recoveredEnergyKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeEmissionFactor = toNonNegativeNumber(
+    raw?.emissionFactorKgPerKwh,
+    'emissionFactorKgPerKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeShare = toSharePercent(raw?.renewableSharePercent, warnings, hasAnyValue)
+
+  return {
+    otherEnergyConsumptionKwh: safeEnergyConsumption,
+    recoveredEnergyKwh: safeRecoveredEnergy,
+    emissionFactorKgPerKwh: safeEmissionFactor,
+    renewableSharePercent: safeShare
+  }
+}
+
+function toNonNegativeNumber(
+  value: number | null | undefined,
+  field: keyof B5Input,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push(`Feltet ${String(field)} mangler og behandles som 0.`)
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push(`Feltet ${String(field)} kan ikke være negativt. 0 anvendes i stedet.`)
+    return 0
+  }
+  return value
+}
+
+function toSharePercent(
+  value: number | null | undefined,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push('Andelen af vedvarende energi mangler og behandles som 0%.')
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push('Andelen af vedvarende energi kan ikke være negativ. 0% anvendes.')
+    return 0
+  }
+  if (value > factors.b5.maximumRenewableSharePercent) {
+    warnings.push(
+      `Andelen af vedvarende energi er begrænset til ${factors.b5.maximumRenewableSharePercent}%.`
+    )
+    return factors.b5.maximumRenewableSharePercent
+  }
+  return value
 }

--- a/packages/shared/calculations/runModule.ts
+++ b/packages/shared/calculations/runModule.ts
@@ -36,7 +36,7 @@ const moduleTitles: Record<ModuleId, string> = {
   B2: 'B2 – Scope 2 varmeforbrug',
   B3: 'B3 – Scope 2 køleforbrug',
   B4: 'B4 – Scope 2 dampforbrug',
-  B5: 'Modul B5',
+  B5: 'B5 – Scope 2 øvrige energileverancer',
   B6: 'Modul B6',
   B7: 'Modul B7',
   B8: 'Modul B8',

--- a/packages/shared/calculations/runModule.ts
+++ b/packages/shared/calculations/runModule.ts
@@ -35,7 +35,7 @@ const moduleTitles: Record<ModuleId, string> = {
   B1: 'B1 – Scope 2 elforbrug',
   B2: 'B2 – Scope 2 varmeforbrug',
   B3: 'B3 – Scope 2 køleforbrug',
-  B4: 'Modul B4',
+  B4: 'B4 – Scope 2 dampforbrug',
   B5: 'Modul B5',
   B6: 'Modul B6',
   B7: 'Modul B7',

--- a/packages/shared/schema/esg-formula-map.json
+++ b/packages/shared/schema/esg-formula-map.json
@@ -1,5 +1,6 @@
 {
   "B1": "B1 = (el-forbrug * emissionsfaktor) - (el-forbrug * emissionsfaktor * (vedvarende% / 100) * 0.9)",
   "B2": "B2 = ((varmeforbrug - genindvinding) * emissionsfaktor) - ((varmeforbrug - genindvinding) * emissionsfaktor * (vedvarende% / 100) * 0.85)",
-  "B3": "B3 = ((køleforbrug - frikøling) * emissionsfaktor) - ((køleforbrug - frikøling) * emissionsfaktor * (vedvarende% / 100) * 0.9)"
+  "B3": "B3 = ((køleforbrug - frikøling) * emissionsfaktor) - ((køleforbrug - frikøling) * emissionsfaktor * (vedvarende% / 100) * 0.9)",
+  "B4": "B4 = ((dampforbrug - genindvundet damp) * emissionsfaktor) - ((dampforbrug - genindvundet damp) * emissionsfaktor * (vedvarende% / 100) * 0.85)"
 }

--- a/packages/shared/schema/esg-formula-map.json
+++ b/packages/shared/schema/esg-formula-map.json
@@ -2,5 +2,6 @@
   "B1": "B1 = (el-forbrug * emissionsfaktor) - (el-forbrug * emissionsfaktor * (vedvarende% / 100) * 0.9)",
   "B2": "B2 = ((varmeforbrug - genindvinding) * emissionsfaktor) - ((varmeforbrug - genindvinding) * emissionsfaktor * (vedvarende% / 100) * 0.85)",
   "B3": "B3 = ((køleforbrug - frikøling) * emissionsfaktor) - ((køleforbrug - frikøling) * emissionsfaktor * (vedvarende% / 100) * 0.9)",
-  "B4": "B4 = ((dampforbrug - genindvundet damp) * emissionsfaktor) - ((dampforbrug - genindvundet damp) * emissionsfaktor * (vedvarende% / 100) * 0.85)"
+  "B4": "B4 = ((dampforbrug - genindvundet damp) * emissionsfaktor) - ((dampforbrug - genindvundet damp) * emissionsfaktor * (vedvarende% / 100) * 0.85)",
+  "B5": "B5 = ((øvrigt energiforbrug - genindvundet energi) * emissionsfaktor) - ((øvrigt energiforbrug - genindvundet energi) * emissionsfaktor * (vedvarende% / 100) * 0.8)"
 }

--- a/packages/shared/schema/esg-input-schema.json
+++ b/packages/shared/schema/esg-input-schema.json
@@ -158,6 +158,47 @@
         }
       },
       "additionalProperties": false
+    },
+    "B5": {
+      "type": "object",
+      "title": "B5Input",
+      "description": "Scope 2 øvrige energileverancer",
+      "properties": {
+        "otherEnergyConsumptionKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Årligt forbrug af den indkøbte energitype (kWh)"
+        },
+        "recoveredEnergyKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Genindvundet energi eller procesudnyttelse der reducerer behovet (kWh)"
+        },
+        "emissionFactorKgPerKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Emissionsfaktor for energileverancen (kg CO2e pr. kWh)"
+        },
+        "renewableSharePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel dokumenteret som vedvarende energi (%)"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/packages/shared/schema/esg-input-schema.json
+++ b/packages/shared/schema/esg-input-schema.json
@@ -9,17 +9,26 @@
       "description": "Scope 2 elforbrug",
       "properties": {
         "electricityConsumptionKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Årligt elforbrug (kWh)"
         },
         "emissionFactorKgPerKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Emissionsfaktor (kg CO2e pr. kWh)"
         },
         "renewableSharePercent": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 100,
           "description": "Andel af strøm indkøbt som vedvarende energi (%)"
@@ -33,22 +42,34 @@
       "description": "Scope 2 varmeforbrug",
       "properties": {
         "heatConsumptionKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Årligt varmeforbrug fra leverandør (kWh)"
         },
         "recoveredHeatKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Genindvundet eller egenproduceret varme trukket fra (kWh)"
         },
         "emissionFactorKgPerKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Emissionsfaktor for varmeleverancen (kg CO2e pr. kWh)"
         },
         "renewableSharePercent": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 100,
           "description": "Andel af certificeret vedvarende varme (%)"
@@ -62,25 +83,78 @@
       "description": "Scope 2 køleforbrug",
       "properties": {
         "coolingConsumptionKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Årligt køleforbrug fra leverandør (kWh)"
         },
         "recoveredCoolingKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Genindvundet eller frikøling trukket fra (kWh)"
         },
         "emissionFactorKgPerKwh": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Emissionsfaktor for køleleverancen (kg CO2e pr. kWh)"
         },
         "renewableSharePercent": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 100,
           "description": "Andel af certificeret vedvarende køling (%)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "B4": {
+      "type": "object",
+      "title": "B4Input",
+      "description": "Scope 2 dampforbrug",
+      "properties": {
+        "steamConsumptionKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Årligt dampforbrug fra leverandør (kWh)"
+        },
+        "recoveredSteamKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Genindvundet kondensat eller procesdamp trukket fra (kWh)"
+        },
+        "emissionFactorKgPerKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Emissionsfaktor for dampforsyningen (kg CO2e pr. kWh)"
+        },
+        "renewableSharePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af certificeret vedvarende damp (%)"
         }
       },
       "additionalProperties": false

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -39,17 +39,28 @@ export const b4InputSchema = z
   })
   .strict()
 
+export const b5InputSchema = z
+  .object({
+    otherEnergyConsumptionKwh: z.number().min(0).nullable(),
+    recoveredEnergyKwh: z.number().min(0).nullable(),
+    emissionFactorKgPerKwh: z.number().min(0).nullable(),
+    renewableSharePercent: z.number().min(0).max(100).nullable()
+  })
+  .strict()
+
 export type B1Input = z.infer<typeof b1InputSchema>
 export type B2Input = z.infer<typeof b2InputSchema>
 export type B3Input = z.infer<typeof b3InputSchema>
 export type B4Input = z.infer<typeof b4InputSchema>
+export type B5Input = z.infer<typeof b5InputSchema>
 
 export const esgInputSchema = z
   .object({
     B1: b1InputSchema.optional(),
     B2: b2InputSchema.optional(),
     B3: b3InputSchema.optional(),
-    B4: b4InputSchema.optional()
+    B4: b4InputSchema.optional(),
+    B5: b5InputSchema.optional()
   })
   .passthrough()
 

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -30,15 +30,26 @@ export const b3InputSchema = z
   })
   .strict()
 
+export const b4InputSchema = z
+  .object({
+    steamConsumptionKwh: z.number().min(0).nullable(),
+    recoveredSteamKwh: z.number().min(0).nullable(),
+    emissionFactorKgPerKwh: z.number().min(0).nullable(),
+    renewableSharePercent: z.number().min(0).max(100).nullable()
+  })
+  .strict()
+
 export type B1Input = z.infer<typeof b1InputSchema>
 export type B2Input = z.infer<typeof b2InputSchema>
 export type B3Input = z.infer<typeof b3InputSchema>
+export type B4Input = z.infer<typeof b4InputSchema>
 
 export const esgInputSchema = z
   .object({
     B1: b1InputSchema.optional(),
     B2: b2InputSchema.optional(),
-    B3: b3InputSchema.optional()
+    B3: b3InputSchema.optional(),
+    B4: b4InputSchema.optional()
   })
   .passthrough()
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,7 +1,7 @@
 /**
  * Fælles typer for ESG-input, moduler og beregningsresultater.
  */
-import type { B1Input, B2Input, B3Input } from './schema'
+import type { B1Input, B2Input, B3Input, B4Input } from './schema'
 
 export const moduleIds = [
   'B1',
@@ -32,6 +32,7 @@ type ModuleInputBase = Partial<Record<ModuleId, unknown>> & {
   B1?: B1Input | null | undefined
   B2?: B2Input | null | undefined
   B3?: B3Input | null | undefined
+  B4?: B4Input | null | undefined
 }
 
 export type ModuleInput = ModuleInputBase & Record<string, unknown>
@@ -52,4 +53,4 @@ export type CalculatedModuleResult = {
   result: ModuleResult
 }
 
-export type { B1Input, B2Input, B3Input }
+export type { B1Input, B2Input, B3Input, B4Input }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,7 +1,7 @@
 /**
  * Fælles typer for ESG-input, moduler og beregningsresultater.
  */
-import type { B1Input, B2Input, B3Input, B4Input } from './schema'
+import type { B1Input, B2Input, B3Input, B4Input, B5Input } from './schema'
 
 export const moduleIds = [
   'B1',
@@ -33,6 +33,7 @@ type ModuleInputBase = Partial<Record<ModuleId, unknown>> & {
   B2?: B2Input | null | undefined
   B3?: B3Input | null | undefined
   B4?: B4Input | null | undefined
+  B5?: B5Input | null | undefined
 }
 
 export type ModuleInput = ModuleInputBase & Record<string, unknown>
@@ -53,4 +54,4 @@ export type CalculatedModuleResult = {
   result: ModuleResult
 }
 
-export type { B1Input, B2Input, B3Input, B4Input }
+export type { B1Input, B2Input, B3Input, B4Input, B5Input }

--- a/packages/tooling/data/modules.csv
+++ b/packages/tooling/data/modules.csv
@@ -4,3 +4,4 @@ B1,string
 B2,object
 B3,object
 B4,object
+B5,object

--- a/packages/tooling/data/modules.csv
+++ b/packages/tooling/data/modules.csv
@@ -3,3 +3,4 @@ B1,object
 B1,string
 B2,object
 B3,object
+B4,object

--- a/packages/tooling/src/csv-to-formula-map.ts
+++ b/packages/tooling/src/csv-to-formula-map.ts
@@ -11,7 +11,9 @@ const formulaOverrides: Record<string, string> = {
   B3:
     'B3 = ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh) - ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)',
   B4:
-    'B4 = ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh) - ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.85)'
+    'B4 = ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh) - ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.85)',
+  B5:
+    'B5 = ((otherEnergyConsumptionKwh - recoveredEnergyKwh) * emissionFactorKgPerKwh) - ((otherEnergyConsumptionKwh - recoveredEnergyKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.8)'
 }
 
 export async function convertCsvToFormulaMap(csvPath: string): Promise<Record<string, string>> {

--- a/packages/tooling/src/csv-to-formula-map.ts
+++ b/packages/tooling/src/csv-to-formula-map.ts
@@ -9,7 +9,9 @@ const formulaOverrides: Record<string, string> = {
   B2:
     'B2 = ((heatConsumptionKwh - recoveredHeatKwh) * emissionFactorKgPerKwh) - ((heatConsumptionKwh - recoveredHeatKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.85)',
   B3:
-    'B3 = ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh) - ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)'
+    'B3 = ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh) - ((coolingConsumptionKwh - recoveredCoolingKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)',
+  B4:
+    'B4 = ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh) - ((steamConsumptionKwh - recoveredSteamKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.85)'
 }
 
 export async function convertCsvToFormulaMap(csvPath: string): Promise<Record<string, string>> {

--- a/packages/tooling/src/csv-to-schema.ts
+++ b/packages/tooling/src/csv-to-schema.ts
@@ -129,11 +129,42 @@ const b4Override = {
   additionalProperties: false
 } as const
 
+const b5Override = {
+  type: 'object',
+  title: 'B5Input',
+  description: 'Scope 2 øvrige energileverancer',
+  properties: {
+    otherEnergyConsumptionKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Årligt forbrug af den indkøbte energitype (kWh)'
+    },
+    recoveredEnergyKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Genindvundet energi eller procesudnyttelse der reducerer behovet (kWh)'
+    },
+    emissionFactorKgPerKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Emissionsfaktor for energileverancen (kg CO2e pr. kWh)'
+    },
+    renewableSharePercent: {
+      type: ['number', 'null'],
+      minimum: 0,
+      maximum: 100,
+      description: 'Andel dokumenteret som vedvarende energi (%)'
+    }
+  },
+  additionalProperties: false
+} as const
+
 const moduleOverrides: Record<string, unknown> = {
   B1: b1Override,
   B2: b2Override,
   B3: b3Override,
-  B4: b4Override
+  B4: b4Override,
+  B5: b5Override
 }
 
 export async function convertCsvToSchema(csvPath: string): Promise<Record<string, unknown>> {

--- a/packages/tooling/src/csv-to-schema.ts
+++ b/packages/tooling/src/csv-to-schema.ts
@@ -99,10 +99,41 @@ const b3Override = {
   additionalProperties: false
 } as const
 
+const b4Override = {
+  type: 'object',
+  title: 'B4Input',
+  description: 'Scope 2 dampforbrug',
+  properties: {
+    steamConsumptionKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Årligt dampforbrug fra leverandør (kWh)'
+    },
+    recoveredSteamKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Genindvundet kondensat eller procesdamp trukket fra (kWh)'
+    },
+    emissionFactorKgPerKwh: {
+      type: ['number', 'null'],
+      minimum: 0,
+      description: 'Emissionsfaktor for dampforsyningen (kg CO2e pr. kWh)'
+    },
+    renewableSharePercent: {
+      type: ['number', 'null'],
+      minimum: 0,
+      maximum: 100,
+      description: 'Andel af certificeret vedvarende damp (%)'
+    }
+  },
+  additionalProperties: false
+} as const
+
 const moduleOverrides: Record<string, unknown> = {
   B1: b1Override,
   B2: b2Override,
-  B3: b3Override
+  B3: b3Override,
+  B4: b4Override
 }
 
 export async function convertCsvToSchema(csvPath: string): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- implement the B4 steam module calculation with dedicated factors, validation, and test coverage
- extend schema generation and shared types to expose B4 inputs alongside existing Scope 2 modules
- wire the new B4 step, ordering, and review presentation into the wizard UI

## Testing
- pnpm --filter @org/shared lint
- pnpm --filter @org/shared typecheck
- pnpm --filter @org/shared test
- pnpm --filter @org/web lint
- pnpm --filter @org/web typecheck
- pnpm --filter @org/tooling lint
- pnpm --filter @org/tooling typecheck

------
https://chatgpt.com/codex/tasks/task_e_68da8d8ec5c48325a2ac1910b8b17be9