### PR TITLE
feat: implement B7 documented renewable electricity module

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -44,6 +44,10 @@ Kvalitetsbarre
 • UI-ændringer kræver 1 Playwright-scenarie.
 • Ingen advarsler i build. 0 lint-fejl. 0 any.
 
+Erfaringer
+• ModuleInput er typet via et index signature. Brug bracket notation (`state['B7']`) fremfor dot-notation for modulnøgler i UI og beregninger for at undgå TypeScript-fejl.
+• Scope 2-reduktioner som B7 må returnere negative værdier; UI bør formidle at negative tal repræsenterer reduktioner fremfor udledninger.
+
 Fejltyper vi kender
 • SSR og @react-pdf/renderer: løses med dynamic import eller route handler.
 • pnpm publish mod forkert registry: tjek publishConfig og .npmrc i pakke og root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fuldt B4-modul for Scope 2 dampforbrug med schema, beregning, UI og tests.
 - Fuldt B5-modul for øvrige Scope 2-energileverancer med schema, beregning, UI og tests.
 - Fuldt B6-modul for Scope 2 nettab i elnettet med schema, beregning, UI og tests.
+- Fuldt B7-modul for dokumenteret vedvarende el med schema, beregning, UI og tests.
 
 ### Changed
 - Replaced the Next.js TypeScript config with an `.mjs` variant to unblock `next lint` and let Next manage app compiler settings.

--- a/apps/web/features/wizard/steps/B4.tsx
+++ b/apps/web/features/wizard/steps/B4.tsx
@@ -56,7 +56,7 @@ const EMPTY_B4: B4Input = {
 }
 
 export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.B4 as B4Input | undefined) ?? EMPTY_B4
+  const current = (state['B4'] as B4Input | undefined) ?? EMPTY_B4
 
   const preview = useMemo<ModuleResult>(() => {
     return runB4({ B4: current } as ModuleInput)

--- a/apps/web/features/wizard/steps/B7.tsx
+++ b/apps/web/features/wizard/steps/B7.tsx
@@ -1,8 +1,159 @@
 /**
- * Wizardtrin for modul B7.
+ * Wizardtrin for modul B7 – dokumenteret vedvarende el.
  */
 'use client'
 
-import { createWizardStep } from './StepTemplate'
+import { useMemo } from 'react'
+import type { ChangeEvent } from 'react'
+import type { B7Input, ModuleInput, ModuleResult } from '@org/shared'
+import { runB7 } from '@org/shared'
+import type { WizardStepProps } from './StepTemplate'
 
-export const B7Step = createWizardStep('B7', 'Modul B7')
+type FieldKey = keyof B7Input
+
+type FieldConfig = {
+  key: FieldKey
+  label: string
+  description: string
+  unit: string
+  placeholder?: string
+}
+
+const FIELD_CONFIG: FieldConfig[] = [
+  {
+    key: 'documentedRenewableKwh',
+    label: 'Dokumenteret vedvarende el',
+    description: 'Mængde el i kWh der er dækket af certifikater eller PPAs.',
+    unit: 'kWh',
+    placeholder: '10000'
+  },
+  {
+    key: 'residualEmissionFactorKgPerKwh',
+    label: 'Residual emissionsfaktor',
+    description: 'Kg CO2e pr. kWh for den residuale elmix der afløses.',
+    unit: 'kg CO2e/kWh',
+    placeholder: '0.233'
+  },
+  {
+    key: 'documentationQualityPercent',
+    label: 'Dokumentationskvalitet',
+    description: 'Andel af dokumentationen der forventes godkendt ved revision.',
+    unit: '%',
+    placeholder: '0-100'
+  }
+]
+
+const EMPTY_B7: B7Input = {
+  documentedRenewableKwh: null,
+  residualEmissionFactorKgPerKwh: null,
+  documentationQualityPercent: null
+}
+
+export function B7Step({ state, onChange }: WizardStepProps): JSX.Element {
+  const current = (state['B7'] as B7Input | undefined) ?? EMPTY_B7
+
+  const preview = useMemo<ModuleResult>(() => {
+    return runB7({ B7: current } as ModuleInput)
+  }, [current])
+
+  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value.replace(',', '.')
+    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
+    const next: B7Input = {
+      ...current,
+      [field]: Number.isFinite(parsed) ? parsed : null
+    }
+    onChange('B7', next)
+  }
+
+  const hasData =
+    preview.trace.some((line) => line.includes('qualityAdjustedKwh')) &&
+    (current.documentedRenewableKwh != null ||
+      current.residualEmissionFactorKgPerKwh != null ||
+      current.documentationQualityPercent != null)
+
+  const valueColour = preview.value < 0 ? '#047857' : '#111827'
+
+  return (
+    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
+      <header style={{ display: 'grid', gap: '0.5rem' }}>
+        <h2>B7 – Dokumenteret vedvarende el</h2>
+        <p>
+          Registrer certifikater, PPAs eller anden dokumenteret vedvarende el. Beregningen estimerer den
+          revisionsrobuste reduktion i Scope 2-udledninger.
+        </p>
+      </header>
+      <section style={{ display: 'grid', gap: '1rem' }}>
+        {FIELD_CONFIG.map((field) => {
+          const value = current[field.key]
+          const commonProps =
+            field.key === 'documentationQualityPercent'
+              ? { min: 0, max: 100 }
+              : { min: 0 }
+          return (
+            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
+              <span style={{ fontWeight: 600 }}>
+                {field.label} ({field.unit})
+              </span>
+              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <input
+                type="number"
+                step="any"
+                value={value ?? ''}
+                placeholder={field.placeholder}
+                onChange={handleFieldChange(field.key)}
+                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                {...commonProps}
+              />
+            </label>
+          )
+        })}
+      </section>
+      <section
+        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
+      >
+        <h3 style={{ margin: 0 }}>Estimat</h3>
+        {hasData ? (
+          <div style={{ display: 'grid', gap: '0.5rem' }}>
+            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
+              {preview.value} {preview.unit}
+            </p>
+            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
+              Negative tal angiver en reduktion i Scope 2-emissioner.
+            </p>
+            <div>
+              <strong>Antagelser</strong>
+              <ul>
+                {preview.assumptions.map((assumption, index) => (
+                  <li key={index}>{assumption}</li>
+                ))}
+              </ul>
+            </div>
+            {preview.warnings.length > 0 && (
+              <div>
+                <strong>Advarsler</strong>
+                <ul>
+                  {preview.warnings.map((warning, index) => (
+                    <li key={index}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <details>
+              <summary>Teknisk trace</summary>
+              <ul>
+                {preview.trace.map((line, index) => (
+                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                    {line}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          </div>
+        ) : (
+          <p style={{ margin: 0 }}>Udfyld felterne for at se den dokumenterede reduktion.</p>
+        )}
+      </section>
+    </form>
+  )
+}

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -38,7 +38,7 @@ export const wizardSteps: WizardStep[] = [
   { id: 'B4', label: 'B4 – Scope 2 dampforbrug', component: B4Step },
   { id: 'B5', label: 'B5 – Scope 2 øvrige energileverancer', component: B5Step },
   { id: 'B6', label: 'B6 – Scope 2 nettab i elnettet', component: B6Step },
-  { id: 'B7', label: 'Modul B7', component: B7Step },
+  { id: 'B7', label: 'B7 – Dokumenteret vedvarende el', component: B7Step },
   { id: 'B8', label: 'Modul B8', component: B8Step },
   { id: 'B9', label: 'Modul B9', component: B9Step },
   { id: 'B10', label: 'Modul B10', component: B10Step },

--- a/packages/shared/calculations/__tests__/runModule.spec.ts
+++ b/packages/shared/calculations/__tests__/runModule.spec.ts
@@ -10,6 +10,7 @@ import { runB3 } from '../modules/runB3'
 import { runB4 } from '../modules/runB4'
 import { runB5 } from '../modules/runB5'
 import { runB6 } from '../modules/runB6'
+import { runB7 } from '../modules/runB7'
 import { factors } from '../factors'
 
 describe('createDefaultResult', () => {
@@ -261,6 +262,63 @@ describe('runB6', () => {
       `Nettab i elnettet er begrænset til ${factors.b6.maximumGridLossPercent}%.`,
       'Feltet emissionFactorKgPerKwh mangler og behandles som 0.',
       'Andelen af vedvarende energi er begrænset til 100%.'
+    ])
+  })
+})
+
+describe('runB7', () => {
+  it('beregner revisionsrobust reduktion baseret på dokumenteret vedvarende el', () => {
+    const input: ModuleInput = {
+      B7: {
+        documentedRenewableKwh: 12_000,
+        residualEmissionFactorKgPerKwh: 0.233,
+        documentationQualityPercent: 90
+      }
+    }
+
+    const result = runB7(input)
+
+    expect(result.value).toBe(-2.391)
+    expect(result.unit).toBe(factors.b7.unit)
+    expect(result.trace).toContain('qualityAdjustedKwh=10260')
+    expect(result.warnings).toEqual([])
+  })
+
+  it('håndterer ugyldig dokumentation og emissionfaktor med passende advarsler', () => {
+    const input: ModuleInput = {
+      B7: {
+        documentedRenewableKwh: -100,
+        residualEmissionFactorKgPerKwh: null,
+        documentationQualityPercent: 150
+      }
+    }
+
+    const result = runB7(input)
+
+    expect(result.value).toBe(0)
+    expect(result.trace).toContain('documentationQualityPercent=100')
+    expect(result.warnings).toEqual([
+      'Feltet documentedRenewableKwh kan ikke være negativt. 0 anvendes i stedet.',
+      'Feltet residualEmissionFactorKgPerKwh mangler og behandles som 0.',
+      'Dokumentationskvalitet er begrænset til 100%.'
+    ])
+  })
+
+  it('advarer når dokumentationskvalitet er lav eller nul', () => {
+    const input: ModuleInput = {
+      B7: {
+        documentedRenewableKwh: 5_000,
+        residualEmissionFactorKgPerKwh: 0.2,
+        documentationQualityPercent: 5
+      }
+    }
+
+    const result = runB7(input)
+
+    expect(result.value).toBe(-0.048)
+    expect(result.trace).toContain('documentationQualityPercent=5')
+    expect(result.warnings).toEqual([
+      'Dokumentationskvalitet under 10% kan blive udfordret i revision.'
     ])
   })
 })

--- a/packages/shared/calculations/factors.ts
+++ b/packages/shared/calculations/factors.ts
@@ -55,5 +55,14 @@ export const factors = {
     maximumGridLossPercent: 20,
     resultPrecision: 3,
     unit: 't CO2e'
+  },
+  b7: {
+    kgToTonnes: 0.001,
+    percentToRatio: 0.01,
+    qualityMitigationRate: 0.95,
+    maximumDocumentationPercent: 100,
+    minimumEffectiveQualityPercent: 10,
+    resultPrecision: 3,
+    unit: 't CO2e'
   }
 } as const

--- a/packages/shared/calculations/modules/runB4.ts
+++ b/packages/shared/calculations/modules/runB4.ts
@@ -16,7 +16,7 @@ export function runB4(input: ModuleInput): ModuleResult {
     `Konvertering fra kg til ton: ${factors.b4.kgToTonnes}`
   ]
 
-  const raw = (input.B4 ?? {}) as B4Input
+  const raw = (input['B4'] ?? {}) as B4Input
   const sanitised = normaliseInput(raw, warnings)
 
   const adjustedSteamConsumptionKwh = Math.max(

--- a/packages/shared/calculations/modules/runB7.ts
+++ b/packages/shared/calculations/modules/runB7.ts
@@ -1,15 +1,128 @@
 /**
- * Beregning for modul B7 med deterministisk stub.
+ * Beregning for modul B7 der vurderer dokumenteret vedvarende el med garantiordninger.
  */
-import type { ModuleInput, ModuleResult } from '../../types'
-import { createDefaultResult } from '../runModule'
+import type { B7Input, ModuleInput, ModuleResult } from '../../types'
+import { factors } from '../factors'
+
+type SanitisedB7 = Required<{
+  [Key in keyof B7Input]: number
+}>
 
 export function runB7(input: ModuleInput): ModuleResult {
-  const result = createDefaultResult('B7', input)
-  return {
-    ...result,
-    trace: [...result.trace, 'runB7'],
-    assumptions: [...result.assumptions, 'Stubberegning'],
-    warnings: result.warnings
+  const warnings: string[] = []
+  const assumptions = [
+    'Reduktion beregnes som dokumenteret vedvarende el multipliceret med residualfaktor.',
+    `Dokumentationskvalitet vægtes med ${Math.round(factors.b7.qualityMitigationRate * 100)}% effektivitet.`,
+    `Konvertering fra kg til ton: ${factors.b7.kgToTonnes}`
+  ]
+
+  const raw = (input['B7'] ?? {}) as B7Input
+  const sanitised = normaliseInput(raw, warnings)
+
+  const qualityAdjustedKwh =
+    sanitised.documentedRenewableKwh *
+    sanitised.documentationQualityPercent *
+    factors.b7.percentToRatio *
+    factors.b7.qualityMitigationRate
+
+  if (sanitised.documentationQualityPercent === 0 && sanitised.documentedRenewableKwh > 0) {
+    warnings.push('Dokumentationskvalitet på 0% betyder, at ingen reduktion kan bogføres.')
   }
+
+  const grossReductionKg = qualityAdjustedKwh * sanitised.residualEmissionFactorKgPerKwh
+  const grossReductionTonnes = grossReductionKg * factors.b7.kgToTonnes
+  const signedReductionTonnes = Number((-grossReductionTonnes).toFixed(factors.b7.resultPrecision))
+  const value = signedReductionTonnes === 0 ? 0 : signedReductionTonnes
+
+  return {
+    value,
+    unit: factors.b7.unit,
+    assumptions,
+    trace: [
+      `documentedRenewableKwh=${sanitised.documentedRenewableKwh}`,
+      `documentationQualityPercent=${sanitised.documentationQualityPercent}`,
+      `qualityAdjustedKwh=${qualityAdjustedKwh}`,
+      `residualEmissionFactorKgPerKwh=${sanitised.residualEmissionFactorKgPerKwh}`,
+      `grossReductionKg=${grossReductionKg}`,
+      `grossReductionTonnes=${grossReductionTonnes}`
+    ],
+    warnings
+  }
+}
+
+function normaliseInput(raw: B7Input, warnings: string[]): SanitisedB7 {
+  const hasAnyValue =
+    raw != null && Object.values(raw).some((value) => value != null && !Number.isNaN(Number(value)))
+
+  const safeRenewableKwh = toNonNegativeNumber(
+    raw?.documentedRenewableKwh,
+    'documentedRenewableKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeResidualFactor = toNonNegativeNumber(
+    raw?.residualEmissionFactorKgPerKwh,
+    'residualEmissionFactorKgPerKwh',
+    warnings,
+    hasAnyValue
+  )
+  const safeQualityPercent = toQualityPercent(
+    raw?.documentationQualityPercent,
+    warnings,
+    hasAnyValue
+  )
+
+  return {
+    documentedRenewableKwh: safeRenewableKwh,
+    residualEmissionFactorKgPerKwh: safeResidualFactor,
+    documentationQualityPercent: safeQualityPercent
+  }
+}
+
+function toNonNegativeNumber(
+  value: number | null | undefined,
+  field: keyof B7Input,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push(`Feltet ${String(field)} mangler og behandles som 0.`)
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push(`Feltet ${String(field)} kan ikke være negativt. 0 anvendes i stedet.`)
+    return 0
+  }
+  return value
+}
+
+function toQualityPercent(
+  value: number | null | undefined,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      warnings.push('Dokumentationskvalitet mangler og behandles som 0%.')
+    }
+    return 0
+  }
+  if (value < 0) {
+    warnings.push('Dokumentationskvalitet kan ikke være negativ. 0% anvendes.')
+    return 0
+  }
+  if (value > factors.b7.maximumDocumentationPercent) {
+    warnings.push(
+      `Dokumentationskvalitet er begrænset til ${factors.b7.maximumDocumentationPercent}%.`
+    )
+    return factors.b7.maximumDocumentationPercent
+  }
+  if (value < factors.b7.minimumEffectiveQualityPercent) {
+    warnings.push(
+      `Dokumentationskvalitet under ${factors.b7.minimumEffectiveQualityPercent}% kan blive udfordret i revision.`
+    )
+  }
+  return value
 }

--- a/packages/shared/calculations/runModule.ts
+++ b/packages/shared/calculations/runModule.ts
@@ -38,7 +38,7 @@ const moduleTitles: Record<ModuleId, string> = {
   B4: 'B4 – Scope 2 dampforbrug',
   B5: 'B5 – Scope 2 øvrige energileverancer',
   B6: 'B6 – Scope 2 nettab i elnettet',
-  B7: 'Modul B7',
+  B7: 'B7 – Dokumenteret vedvarende el',
   B8: 'Modul B8',
   B9: 'Modul B9',
   B10: 'Modul B10',

--- a/packages/shared/schema/esg-formula-map.json
+++ b/packages/shared/schema/esg-formula-map.json
@@ -4,5 +4,6 @@
   "B3": "B3 = ((køleforbrug - frikøling) * emissionsfaktor) - ((køleforbrug - frikøling) * emissionsfaktor * (vedvarende% / 100) * 0.9)",
   "B4": "B4 = ((dampforbrug - genindvundet damp) * emissionsfaktor) - ((dampforbrug - genindvundet damp) * emissionsfaktor * (vedvarende% / 100) * 0.85)",
   "B5": "B5 = ((øvrigt energiforbrug - genindvundet energi) * emissionsfaktor) - ((øvrigt energiforbrug - genindvundet energi) * emissionsfaktor * (vedvarende% / 100) * 0.8)",
-  "B6": "B6 = (elforbrug * nettab% / 100 * emissionsfaktor) - (elforbrug * nettab% / 100 * emissionsfaktor * (vedvarende% / 100) * 0.9)"
+  "B6": "B6 = (elforbrug * nettab% / 100 * emissionsfaktor) - (elforbrug * nettab% / 100 * emissionsfaktor * (vedvarende% / 100) * 0.9)",
+  "B7": "B7 = -(dokumenteret vedvarende el * dokumentationskvalitet% / 100 * 0.95 * residual emissionsfaktor)"
 }

--- a/packages/shared/schema/esg-input-schema.json
+++ b/packages/shared/schema/esg-input-schema.json
@@ -241,6 +241,39 @@
         }
       },
       "additionalProperties": false
+    },
+    "B7": {
+      "type": "object",
+      "title": "B7Input",
+      "description": "Dokumenteret vedvarende el",
+      "properties": {
+        "documentedRenewableKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Dokumenteret vedvarende el dækket af certifikater (kWh)"
+        },
+        "residualEmissionFactorKgPerKwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Residual emissionsfaktor for elmixet (kg CO2e pr. kWh)"
+        },
+        "documentationQualityPercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Dokumentationskvalitet der forventes godkendt (%)"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -58,6 +58,14 @@ export const b6InputSchema = z
   })
   .strict()
 
+export const b7InputSchema = z
+  .object({
+    documentedRenewableKwh: z.number().min(0).nullable(),
+    residualEmissionFactorKgPerKwh: z.number().min(0).nullable(),
+    documentationQualityPercent: z.number().min(0).max(100).nullable()
+  })
+  .strict()
+
 
 export type B1Input = z.infer<typeof b1InputSchema>
 export type B2Input = z.infer<typeof b2InputSchema>
@@ -66,6 +74,7 @@ export type B4Input = z.infer<typeof b4InputSchema>
 export type B5Input = z.infer<typeof b5InputSchema>
 
 export type B6Input = z.infer<typeof b6InputSchema>
+export type B7Input = z.infer<typeof b7InputSchema>
 
 
 export const esgInputSchema = z
@@ -75,7 +84,8 @@ export const esgInputSchema = z
     B3: b3InputSchema.optional(),
     B4: b4InputSchema.optional(),
     B5: b5InputSchema.optional(),
-    B6: b6InputSchema.optional()
+    B6: b6InputSchema.optional(),
+    B7: b7InputSchema.optional()
 
   })
   .passthrough()

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -2,7 +2,7 @@
  * Fælles typer for ESG-input, moduler og beregningsresultater.
  */
 
-import type { B1Input, B2Input, B3Input, B4Input, B5Input, B6Input } from './schema'
+import type { B1Input, B2Input, B3Input, B4Input, B5Input, B6Input, B7Input } from './schema'
 
 
 export const moduleIds = [
@@ -37,6 +37,7 @@ type ModuleInputBase = Partial<Record<ModuleId, unknown>> & {
   B4?: B4Input | null | undefined
   B5?: B5Input | null | undefined
   B6?: B6Input | null | undefined
+  B7?: B7Input | null | undefined
 
 }
 
@@ -58,5 +59,5 @@ export type CalculatedModuleResult = {
   result: ModuleResult
 }
 
-export type { B1Input, B2Input, B3Input, B4Input, B5Input, B6Input }
+export type { B1Input, B2Input, B3Input, B4Input, B5Input, B6Input, B7Input }
 

--- a/packages/tooling/src/__tests__/csv-to-formula-map.spec.ts
+++ b/packages/tooling/src/__tests__/csv-to-formula-map.spec.ts
@@ -24,8 +24,8 @@ describe('convertCsvToFormulaMap', () => {
 
     const map = await convertCsvToFormulaMap(csvPath)
 
-    expect(map.B4).toContain('steamConsumptionKwh')
-    expect(map.B4).not.toBe('B4 = input')
-    expect(map.B7).toBe('B7 = input')
+    expect(map['B4']).toContain('steamConsumptionKwh')
+    expect(map['B4']).not.toBe('B4 = input')
+    expect(map['B7']).toContain('documentationQualityPercent/100')
   })
 })

--- a/packages/tooling/src/csv-to-formula-map.ts
+++ b/packages/tooling/src/csv-to-formula-map.ts
@@ -15,7 +15,9 @@ const formulaOverrides: Record<string, string> = {
   B5:
     'B5 = ((otherEnergyConsumptionKwh - recoveredEnergyKwh) * emissionFactorKgPerKwh) - ((otherEnergyConsumptionKwh - recoveredEnergyKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.8)',
   B6:
-    'B6 = (electricitySuppliedKwh * gridLossPercent/100 * emissionFactorKgPerKwh) - (electricitySuppliedKwh * gridLossPercent/100 * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)'
+    'B6 = (electricitySuppliedKwh * gridLossPercent/100 * emissionFactorKgPerKwh) - (electricitySuppliedKwh * gridLossPercent/100 * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)',
+  B7:
+    'B7 = -(documentedRenewableKwh * documentationQualityPercent/100 * 0.95 * residualEmissionFactorKgPerKwh)'
 
 }
 


### PR DESCRIPTION
## Summary
- implement the B7 module to calculate documented renewable electricity reductions with updated factors, schema, types and tests
- replace the B7 wizard step with a data entry form that previews negative emission reductions
- extend the formula map tooling and repository guidance to cover the new module and bracket notation access

## Testing
- pnpm -w run typecheck
- pnpm --filter @org/shared run test

------
https://chatgpt.com/codex/tasks/task_e_68dab1c3bccc8325b9409c76b003ed06