### PR TITLE
Add module runbooks for B1 and C10

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ ESG-as-a-Service (ESG reporting platform)
 - [Baseline quality metrics](docs/quality/baseline.md)
 - [Architectural decision records](docs/adr)
 - [Migrations](docs/migrations)
-- [Runbooks](docs/runbooks)
+- Runbooks
+  - [Runbook-overblik](docs/runbooks/overview.md)
+  - [B1 Scope 2 elforbrug](docs/runbooks/module-b1.md)
+  - [C10 upstream leasede aktiver](docs/runbooks/module-c10.md)
+  - [D1 Metode & governance](docs/runbooks/module-d1.md)
+  - [Publishing](docs/runbooks/publishing.md)
 - [Changelog](CHANGELOG.md)
 - [Modulreferencer](docs/modules)
 

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,11 @@
+# Modulreferencer og runbooks
+
+Brug oversigten til hurtigt at finde både modulreferencer og runbooks for beregningerne i EAAS-platformen.
+
+| Modul                          | Modulreference                          | Runbook                              |
+| ------------------------------ | --------------------------------------- | ------------------------------------ |
+| B1 – Scope 2 elforbrug         | (kommer i Scope 2-oversigten)           | [Runbook](../runbooks/module-b1.md)  |
+| C10 – Upstream leasede aktiver | [Scope 3 C10 reference](scope-3-c10.md) | [Runbook](../runbooks/module-c10.md) |
+| D1 – Metode & governance       | –                                       | [Runbook](../runbooks/module-d1.md)  |
+
+> Se også det samlede [runbook-overblik](../runbooks/overview.md) for anbefalet rækkefølge.

--- a/docs/modules/scope-3-c10.md
+++ b/docs/modules/scope-3-c10.md
@@ -1,10 +1,13 @@
 # Scope 3 modulreference – C10 upstream leasede aktiver
 
+> Se også [runbooken for C10](../runbooks/module-c10.md) for en trin-for-trin guide til formål, UI-flow og QA.
+
 Denne reference supplerer de eksisterende Scope 3-moduler med detaljer for C10, der nu beregner
 upstream leasede aktiver. Brug dokumentet til at afstemme dataindsamling, valideringer og
 forventede advarsler mellem produkt, dataejere og assurance.
 
 ## Inputfelter
+
 - **Leased asset lines**: Op til 20 linjer kan registreres.
   - **Energitype** (`electricity` eller `heat`) styrer standardintensitet og emissionsfaktor.
   - **Areal (m²)** anvendes som fallback til at beregne energi, når kWh ikke er kendt.
@@ -13,11 +16,12 @@ forventede advarsler mellem produkt, dataejere og assurance.
   - **Dokumentationskvalitet (%)** bruges til at flagge linjer med lavt revisionsniveau.
 
 ## Standardantagelser og valideringer
-| Element | Elektricitet | Varme |
-| --- | --- | --- |
-| Standardintensitet (kWh/m²) | 95 | 80 |
-| Standard emissionsfaktor (kg CO₂e/kWh) | 0,18 | 0,07 |
-| Dokumentationskvalitet (standard) | 100 | 100 |
+
+| Element                                | Elektricitet | Varme |
+| -------------------------------------- | ------------ | ----- |
+| Standardintensitet (kWh/m²)            | 95           | 80    |
+| Standard emissionsfaktor (kg CO₂e/kWh) | 0,18         | 0,07  |
+| Dokumentationskvalitet (standard)      | 100          | 100   |
 
 - Felter for areal, energi, emissionsfaktor og dokumentationskvalitet valideres til ikke-negative værdier.
 - Manglende værdier behandles som 0 (eller standard) og udløser en advarsel i resultatet.
@@ -25,6 +29,7 @@ forventede advarsler mellem produkt, dataejere og assurance.
 - Hvis både areal og energiforbrug mangler/er 0, udelades linjen fra beregningen.
 
 ## Beregning
+
 1. For hver linje vælges den effektive energi:
    - Hvis `energyConsumptionKwh` er >0 anvendes værdien direkte.
    - Ellers beregnes `floorAreaSqm × standardintensitet` baseret på energitypen.
@@ -33,6 +38,7 @@ forventede advarsler mellem produkt, dataejere og assurance.
 4. Resultatet afrundes til tre decimaler.
 
 ## Output og sporbarhed
+
 - Outputtet rapporteres i ton CO₂e (tre decimaler).
 - Trace-listen dokumenterer:
   - Sanitiserede inputværdier for hver linje.
@@ -44,6 +50,7 @@ forventede advarsler mellem produkt, dataejere og assurance.
   - Linjer der er blevet udeladt pga. manglende data.
 
 ## UI-overblik
+
 - Wizardtrinnet tilbyder dynamiske linjer med mulighed for at tilføje/fjerne aktiver.
 - Feltet for energitype skifter placeholder for emissionsfaktoren til den relevante standard.
 - Resultatkortet viser antagelser, warnings og trace direkte, så brugere kan validere input inden eksport.

--- a/docs/runbooks/module-b1.md
+++ b/docs/runbooks/module-b1.md
@@ -1,0 +1,38 @@
+# Runbook – B1 Scope 2 elforbrug
+
+Denne runbook beskriver, hvordan modul B1 understøtter indsamling af eldata og beregner nettoemissioner for Scope 2.
+
+## Formål
+
+- Dokumentere årligt elforbrug, emissionsfaktor og andel vedvarende energi for organisationen.
+- Udregne netto ton CO₂e efter fradrag for certificeret vedvarende indkøb.
+- Give produkt- og assurance-teams et fælles referencepunkt for advarsler og antagelser i modulet.
+
+## Arbejdsgang i UI
+
+1. Navigér til `/wizard` og vælg Scope 2-sektionen.
+2. Udfyld felterne for **Årligt elforbrug**, **Emissionsfaktor** og **Vedvarende andel** i [B1-step-komponenten](../../apps/web/features/wizard/steps/B1.tsx).
+3. Brugere kan indtaste decimaltal med komma eller punktum; værdier normaliseres automatisk.
+4. Resultatkortet viser netto ton CO₂e, antagelser, advarsler og teknisk trace, så data kan valideres før eksport.
+
+## Beregningslogik
+
+- Beregningen implementeres i [runB1-funktionen](../../packages/shared/calculations/modules/runB1.ts).
+- `grossEmissionsKg = electricityConsumptionKwh × emissionFactorKgPerKwh`.
+- Reduktion for vedvarende energi = `grossEmissionsKg × (renewableSharePercent ÷ 100) × 0,9` (se `factors.b1.renewableMitigationRate`).
+- Netto ton CO₂e = `max(0, grossEmissionsKg − reduktion) × 0,001`, afrundet til den præcision, der er defineret i faktorkonfigurationen.
+- Manglende eller negative tal erstattes af 0 via normaliseringsfunktionerne, og værdier over den maksimale procent begrænses.
+- Formlerne dokumenteres også i [ESG-formula-mappet](../../packages/shared/schema/esg-formula-map.json) og valideres af `b1InputSchema` i [schemasamlingen](../../packages/shared/schema/index.ts).
+
+## Kvalitetssikring
+
+- Inputtyper og begrænsninger er defineret i [`B1Input`-schemaet](../../packages/shared/schema/esg-input-schema.json) og eksporteres fra [schemaindekset](../../packages/shared/schema/index.ts).
+- Modulresultatet testes sammen med andre moduler i [`runModule.spec.ts`](../../packages/shared/calculations/__tests__/runModule.spec.ts).
+- Wizardtrinnet genbruger layoutet fra [`StepTemplate`](../../apps/web/features/wizard/steps/StepTemplate.tsx), hvilket reducerer risikoen for UI-regressioner og gør manuelle QA-tjek fra [baseline-guiden](../quality/baseline.md) hurtigere.
+- Advarsler for manglende felter og andele over 100 % sikrer, at support hurtigt kan identificere datafejl.
+
+## Videreudvikling
+
+- Overvej at tilføje felt til timekorrelerede certifikater med egen reduktionssats.
+- Suppler datafeeds fra energileverandørers API'er, så elforbrug kan indlæses automatisk.
+- Udvid runbooken med konkrete datakilder og dokumentationskrav, når flere organisationer er onboardet.

--- a/docs/runbooks/module-c10.md
+++ b/docs/runbooks/module-c10.md
@@ -1,0 +1,38 @@
+# Runbook – C10 Upstream leasede aktiver
+
+Denne runbook beskriver, hvordan modul C10 estimerer emissioner fra upstream leasede aktiver via kombinationen af areal- og energidata.
+
+## Formål
+
+- Samle dokumentation for leasede bygninger/aktiver, hvor virksomheden er ansvarlig for energiforbruget.
+- Understøtte både direkte energimålinger og estimering fra areal med standardintensiteter.
+- Fremhæve datakvalitet gennem procentbaserede vurderinger, så revision og support kan prioritere opfølgning.
+
+## Arbejdsgang i UI
+
+1. Tilføj én eller flere linjer i [C10-step-komponenten](../../apps/web/features/wizard/steps/C10.tsx).
+2. Vælg energitype (elektricitet eller varme), og udfyld enten areal eller energiforbrug. Begge felter kan udfyldes for at dokumentere input.
+3. Justér emissionsfaktor og dokumentationskvalitet pr. linje efter behov. Felterne er forudfyldt med standardværdier fra `c10EnergyConfigurations`.
+4. Resultatkortet viser ton CO₂e, antagelser, advarsler og teknisk trace for hver linje, så brugere kan verificere beregningen.
+
+## Beregningslogik
+
+- Implementeret i [runC10-funktionen](../../packages/shared/calculations/modules/runC10.ts).
+- For hver linje vælges energitypen, og manglende energiforbrug beregnes som `floorAreaSqm × standardintensitet`.
+- Emissioner pr. linje = `energi (kWh) × emissionsfaktor`. Summen konverteres til ton CO₂e med `factors.c10.kgToTonnes`.
+- Dokumentationskvalitet anvendes til warnings: værdier under `lowDocumentationQualityThresholdPercent` udløser en besked.
+- Input normaliseres: negative tal erstattes af 0, manglende værdier bruger standarder, og ugyldige energityper falder tilbage til elektricitet.
+- Understøttende formler findes i [ESG-formula-mappet](../../packages/shared/schema/esg-formula-map.json), mens feltdefinitioner ligger i [`c10InputSchema`](../../packages/shared/schema/index.ts).
+
+## Kvalitetssikring
+
+- Felter, defaultværdier og begrænsninger er defineret i [`C10Input`-schemaet](../../packages/shared/schema/esg-input-schema.json) og eksporteres fra [schemaindekset](../../packages/shared/schema/index.ts).
+- Beregningen dækkes i [`runModule.spec.ts`](../../packages/shared/calculations/__tests__/runModule.spec.ts), som opretter både glade scenarier og edge cases for modul C10.
+- Wizardtrinnet bygger oven på [`StepTemplate`](../../apps/web/features/wizard/steps/StepTemplate.tsx) og understøtter manuelle QA-tjek fra [baseline-guiden](../quality/baseline.md), hvor support gennemgår warnings og trace.
+- Før release skal `pnpm lint`, `pnpm typecheck` og `pnpm test` være grønne, så beregning og præsentation er stabil før produktion.
+
+## Videreudvikling
+
+- Tilføj flere energityper (fx damp eller køling) med egne standardintensiteter og faktorprofiler.
+- Udbyg warnings med forslag til datakilder, når dokumentationskvaliteten er lav.
+- Integrér upstream leasede aktiver med facility management-systemer for at automatisere inputopdateringer.

--- a/docs/runbooks/overview.md
+++ b/docs/runbooks/overview.md
@@ -1,0 +1,11 @@
+# Runbook-overblik
+
+Denne oversigt samler alle modulrunbooks og den anbefalede gennemførelsesrækkefølge, så support og produkt hurtigt kan finde den rette dokumentation.
+
+| Rækkefølge | Modul                          | Fokus                                                                                   | Runbook                        |
+| ---------- | ------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------ |
+| 1          | B1 – Scope 2 elforbrug         | Indtast elforbrug, emissionsfaktor og vedvarende andel for at beregne netto ton CO₂e.   | [module-b1.md](module-b1.md)   |
+| 2          | C10 – Upstream leasede aktiver | Registrér leasede aktiver med areal- eller energidata og vurder dokumentationskvalitet. | [module-c10.md](module-c10.md) |
+| 3          | D1 – Metode & governance       | Dokumentér governance-metoder og strategi for at samle en compliance-score.             | [module-d1.md](module-d1.md)   |
+
+> Brug oversigten som indgang til både UI-flow, beregningslogik og QA-krav for hvert modul.


### PR DESCRIPTION
## Summary
- document the B1 scope 2 and C10 upstream leased assets flows with dedicated runbooks based on the D1 template
- add a runbook overview plus modules index links so support can find module documentation quickly
- refresh README navigation to surface the new runbooks alongside existing docs

## Testing
- pnpm exec prettier -c README.md docs/runbooks/module-b1.md docs/runbooks/module-c10.md docs/runbooks/overview.md docs/modules/README.md docs/modules/scope-3-c10.md

------
https://chatgpt.com/codex/tasks/task_e_68dcec3ad36c8325987dc3ae4f1a71c4