### PR TITLE
Update B1 scope-2 inputs to new electricity schema

### DIFF
--- a/docs/runbooks/module-b1.md
+++ b/docs/runbooks/module-b1.md
@@ -4,25 +4,24 @@ Denne runbook beskriver, hvordan modul B1 understøtter indsamling af eldata og 
 
 ## Formål
 
-- Dokumentere årligt elforbrug, emissionsfaktor og andel vedvarende energi for organisationen.
-- Udregne netto ton CO₂e efter fradrag for certificeret vedvarende indkøb.
-- Give produkt- og assurance-teams et fælles referencepunkt for advarsler og antagelser i modulet.
+- Dokumentere indkøbt elektricitet, valgt emissionsfaktor og rapporteringsmetode.
+- Udregne ton CO₂e ud fra kWh × emissionsfaktor uden særskilt reduktionsled.
+- Give produkt- og assurance-teams et fælles referencepunkt for datakvalitet og sporbarhed.
 
 ## Arbejdsgang i UI
 
 1. Navigér til `/wizard` og vælg Scope 2-sektionen.
-2. Udfyld felterne for **Årligt elforbrug**, **Emissionsfaktor** og **Vedvarende andel** i [B1-step-komponenten](../../apps/web/features/wizard/steps/B1.tsx).
+2. Udfyld felterne for **Elforbrug**, **Emissionsfaktorkilde**, **Emissionsfaktor**, **Beregningsmetode** og **Dokumentationskvalitet** i [B1-step-komponenten](../../apps/web/features/wizard/steps/B1.tsx).
 3. Brugere kan indtaste decimaltal med komma eller punktum; værdier normaliseres automatisk.
 4. Resultatkortet viser netto ton CO₂e, antagelser, advarsler og teknisk trace, så data kan valideres før eksport.
 
 ## Beregningslogik
 
 - Beregningen implementeres i [runB1-funktionen](../../packages/shared/calculations/modules/runB1.ts).
-- `grossEmissionsKg = electricityConsumptionKwh × emissionFactorKgPerKwh`.
-- Reduktion for vedvarende energi = `grossEmissionsKg × (renewableSharePercent ÷ 100) × 0,9` (se `factors.b1.renewableMitigationRate`).
-- Netto ton CO₂e = `max(0, grossEmissionsKg − reduktion) × 0,001`, afrundet til den præcision, der er defineret i faktorkonfigurationen.
-- Manglende eller negative tal erstattes af 0 via normaliseringsfunktionerne, og værdier over den maksimale procent begrænses.
-- Formlerne dokumenteres også i [ESG-formula-mappet](../../packages/shared/schema/esg-formula-map.json) og valideres af `b1InputSchema` i [schemasamlingen](../../packages/shared/schema/index.ts).
+- `emissionsKg = consumptionKwh × emissionFactorKgPerKwh`.
+- Ton CO₂e = `emissionsKg × 0,001`, afrundet efter `factors.b1.resultPrecision`.
+- Manglende, negative eller ugyldige felter normaliseres til sikre standarder (0 eller standardfaktor) og udløser advarsler.
+- Formlen dokumenteres i [ESG-formula-mappet](../../packages/shared/schema/esg-formula-map.json) og valideres af `b1InputSchema` i [schemasamlingen](../../packages/shared/schema/index.ts).
 
 ## Kvalitetssikring
 

--- a/packages/shared/calculations/modules/runB1.ts
+++ b/packages/shared/calculations/modules/runB1.ts
@@ -1,46 +1,76 @@
 /**
- * Beregning for modul B1 der vurderer nettoemissioner fra elforbrug.
+ * Beregning for modul B1 der vurderer emissioner fra indkøbt elektricitet.
  */
 import type { B1Input, ModuleInput, ModuleResult } from '../../types'
 import { factors } from '../factors'
 
-type SanitisedB1 = Required<{
-  [Key in keyof B1Input]: number
-}>
+export type B1EmissionFactorSource = 'landefaktor' | 'residualMix'
+
+export const b1EmissionFactorOptions: Array<{
+  value: B1EmissionFactorSource
+  label: string
+  description: string
+  defaultEmissionFactorKgPerKwh: number
+}> = [
+  {
+    value: 'landefaktor',
+    label: 'Landefaktor',
+    description: 'National gennemsnitsfaktor for el (location-based).',
+    defaultEmissionFactorKgPerKwh: 0.233
+  },
+  {
+    value: 'residualMix',
+    label: 'Residualmix',
+    description: 'Residualmix til brug ved markedsbaseret opgørelse.',
+    defaultEmissionFactorKgPerKwh: 0.377
+  }
+]
+
+export const b1CalculationMethodOptions = [
+  { value: 'locationBased', label: 'Location-based' },
+  { value: 'marketBased', label: 'Market-based' }
+] as const
+
+type SanitisedB1 = {
+  consumptionKwh: number
+  emissionFactorKgPerKwh: number
+  emissionFactorSource: B1EmissionFactorSource
+  calculationMethod: (typeof b1CalculationMethodOptions)[number]['value']
+  documentationQualityPercent: number
+}
 
 export function runB1(input: ModuleInput): ModuleResult {
   const warnings: string[] = []
   const assumptions = [
-    `Reduktion for vedvarende energi: ${Math.round(factors.b1.renewableMitigationRate * 100)}%`,
-    `Konvertering fra kg til ton: ${factors.b1.kgToTonnes}`
+    'Emissioner beregnes som kWh × emissionsfaktor.',
+    `Konvertering fra kg til ton: ${factors.b1.kgToTonnes}.`
   ]
 
   const raw = (input.B1 ?? {}) as B1Input
-
   const sanitised = normaliseInput(raw, warnings)
 
-  const grossEmissionsKg = sanitised.electricityConsumptionKwh * sanitised.emissionFactorKgPerKwh
-  const renewableReductionKg =
-    grossEmissionsKg *
-    sanitised.renewableSharePercent *
-    factors.b1.percentToRatio *
-    factors.b1.renewableMitigationRate
-  const netEmissionsKg = Math.max(0, grossEmissionsKg - renewableReductionKg)
-  const netEmissionsTonnes = netEmissionsKg * factors.b1.kgToTonnes
+  const emissionsKg = sanitised.consumptionKwh * sanitised.emissionFactorKgPerKwh
+  const emissionsTonnes = emissionsKg * factors.b1.kgToTonnes
+  const value = Number(emissionsTonnes.toFixed(factors.b1.resultPrecision))
 
-  const value = Number(netEmissionsTonnes.toFixed(factors.b1.resultPrecision))
+  if (sanitised.documentationQualityPercent < 60) {
+    warnings.push(
+      'Dokumentationskvaliteten er under 60%. Overvej at forbedre data eller anvende konservativ tilgang.'
+    )
+  }
 
   return {
     value,
     unit: factors.b1.unit,
     assumptions,
     trace: [
-      `electricityConsumptionKwh=${sanitised.electricityConsumptionKwh}`,
+      `consumptionKwh=${sanitised.consumptionKwh}`,
+      `emissionFactorSource=${sanitised.emissionFactorSource}`,
       `emissionFactorKgPerKwh=${sanitised.emissionFactorKgPerKwh}`,
-      `renewableSharePercent=${sanitised.renewableSharePercent}`,
-      `grossEmissionsKg=${grossEmissionsKg}`,
-      `renewableReductionKg=${renewableReductionKg}`,
-      `netEmissionsTonnes=${netEmissionsTonnes}`
+      `calculationMethod=${sanitised.calculationMethod}`,
+      `documentationQualityPercent=${sanitised.documentationQualityPercent}`,
+      `emissionsKg=${emissionsKg}`,
+      `emissionsTonnes=${emissionsTonnes}`
     ],
     warnings
   }
@@ -49,26 +79,29 @@ export function runB1(input: ModuleInput): ModuleResult {
 function normaliseInput(raw: B1Input, warnings: string[]): SanitisedB1 {
   const hasAnyValue =
     raw != null &&
-    Object.values(raw).some((value) => value != null && !Number.isNaN(Number(value)))
+    Object.values(raw).some((value) => value != null && value !== '' && !Number.isNaN(Number(value)))
 
-  const safeElectricity = toNonNegativeNumber(
-    raw?.electricityConsumptionKwh,
-    'electricityConsumptionKwh',
-    warnings,
-    hasAnyValue
-  )
-  const safeEmissionFactor = toNonNegativeNumber(
+  const consumption = toNonNegativeNumber(raw?.consumptionKwh, 'consumptionKwh', warnings, hasAnyValue)
+  const source = toEmissionFactorSource(raw?.emissionFactorSource, warnings)
+  const emissionFactor = toEmissionFactor(
     raw?.emissionFactorKgPerKwh,
-    'emissionFactorKgPerKwh',
+    source,
     warnings,
     hasAnyValue
   )
-  const safeShare = toSharePercent(raw?.renewableSharePercent, warnings, hasAnyValue)
+  const method = toCalculationMethod(raw?.calculationMethod, warnings)
+  const documentationQuality = toDocumentationQuality(
+    raw?.documentationQualityPercent,
+    warnings,
+    hasAnyValue
+  )
 
   return {
-    electricityConsumptionKwh: safeElectricity,
-    emissionFactorKgPerKwh: safeEmissionFactor,
-    renewableSharePercent: safeShare
+    consumptionKwh: consumption,
+    emissionFactorSource: source,
+    emissionFactorKgPerKwh: emissionFactor,
+    calculationMethod: method,
+    documentationQualityPercent: documentationQuality
   }
 }
 
@@ -91,26 +124,75 @@ function toNonNegativeNumber(
   return value
 }
 
-function toSharePercent(
+function toEmissionFactor(
+  value: number | null | undefined,
+  source: B1EmissionFactorSource,
+  warnings: string[],
+  emitMissingWarning: boolean
+): number {
+  if (value == null || Number.isNaN(value)) {
+    if (emitMissingWarning) {
+      const option = b1EmissionFactorOptions.find((item) => item.value === source)
+      warnings.push(
+        `Emissionsfaktor mangler. Standard for ${option?.label ?? source} anvendes: ${option?.defaultEmissionFactorKgPerKwh} kg CO2e/kWh.`
+      )
+    }
+    return (
+      b1EmissionFactorOptions.find((item) => item.value === source)?.defaultEmissionFactorKgPerKwh ??
+      b1EmissionFactorOptions[0].defaultEmissionFactorKgPerKwh
+    )
+  }
+  if (value < 0) {
+    warnings.push(`Feltet emissionFactorKgPerKwh kan ikke være negativt. 0 anvendes i stedet.`)
+    return 0
+  }
+  return value
+}
+
+function toEmissionFactorSource(
+  value: B1Input['emissionFactorSource'],
+  warnings: string[]
+): B1EmissionFactorSource {
+  if (value === 'landefaktor' || value === 'residualMix') {
+    return value
+  }
+  if (value != null) {
+    warnings.push('Ukendt emissionsfaktorkilde. Landefaktor anvendes som standard.')
+  }
+  return 'landefaktor'
+}
+
+function toCalculationMethod(
+  value: B1Input['calculationMethod'],
+  warnings: string[]
+): (typeof b1CalculationMethodOptions)[number]['value'] {
+  if (value === 'locationBased' || value === 'marketBased') {
+    return value
+  }
+  if (value != null) {
+    warnings.push('Ukendt beregningsmetode. Location-based anvendes som standard.')
+  }
+  return 'locationBased'
+}
+
+function toDocumentationQuality(
   value: number | null | undefined,
   warnings: string[],
   emitMissingWarning: boolean
 ): number {
   if (value == null || Number.isNaN(value)) {
     if (emitMissingWarning) {
-      warnings.push('Andelen af vedvarende energi mangler og behandles som 0%.')
+      warnings.push('Dokumentationskvalitet mangler og behandles som 100%.')
     }
-    return 0
+    return 100
   }
   if (value < 0) {
-    warnings.push('Andelen af vedvarende energi kan ikke være negativ. 0% anvendes.')
+    warnings.push('Dokumentationskvalitet kan ikke være negativ. 0% anvendes i stedet.')
     return 0
   }
-  if (value > factors.b1.maximumRenewableSharePercent) {
-    warnings.push(
-      `Andelen af vedvarende energi er begrænset til ${factors.b1.maximumRenewableSharePercent}%.`
-    )
-    return factors.b1.maximumRenewableSharePercent
+  if (value > 100) {
+    warnings.push('Dokumentationskvalitet er begrænset til 100%.')
+    return 100
   }
   return value
 }

--- a/packages/shared/schema/esg-formula-map.json
+++ b/packages/shared/schema/esg-formula-map.json
@@ -3,7 +3,7 @@
   "A2": "A2 = \u2211 (brændselsmængde * emissionsfaktor) / 1000. Kilometer registreres til intensitetsopfølgning.",
   "A3": "A3 = \u2211 (proces-output (ton) * emissionsfaktor (kg CO2e/ton)) / 1000 med standardfaktorer for cement, kalk, ammoniak og aluminium.",
   "A4": "Scope 1 flugtige emissioner = Σ (fyldning kg × lækageandel % × GWP100) ÷ 1.000.",
-  "B1": "B1 = (el-forbrug * emissionsfaktor) - (el-forbrug * emissionsfaktor * (vedvarende% / 100) * 0.9)",
+  "B1": "B1 = elforbrug (kWh) × valgt emissionsfaktor",
   "B2": "B2 = ((varmeforbrug - genindvinding) * emissionsfaktor) - ((varmeforbrug - genindvinding) * emissionsfaktor * (vedvarende% / 100) * 0.85)",
   "B3": "B3 = ((køleforbrug - frikøling) * emissionsfaktor) - ((køleforbrug - frikøling) * emissionsfaktor * (vedvarende% / 100) * 0.9)",
   "B4": "B4 = ((dampforbrug - genindvundet damp) * emissionsfaktor) - ((dampforbrug - genindvundet damp) * emissionsfaktor * (vedvarende% / 100) * 0.85)",

--- a/packages/shared/schema/esg-input-schema.json
+++ b/packages/shared/schema/esg-input-schema.json
@@ -274,13 +274,24 @@
       "title": "B1Input",
       "description": "Scope 2 elforbrug",
       "properties": {
-        "electricityConsumptionKwh": {
+        "consumptionKwh": {
           "type": [
             "number",
             "null"
           ],
           "minimum": 0,
-          "description": "Årligt elforbrug (kWh)"
+          "description": "Indkøbt elektricitet i kWh."
+        },
+        "emissionFactorSource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "landefaktor",
+            "residualMix"
+          ],
+          "description": "Valgt kilde til emissionsfaktor (landefaktor eller residualmix)."
         },
         "emissionFactorKgPerKwh": {
           "type": [
@@ -288,16 +299,35 @@
             "null"
           ],
           "minimum": 0,
-          "description": "Emissionsfaktor (kg CO2e pr. kWh)"
+          "description": "Emissionsfaktor i kg CO2e pr. kWh."
         },
-        "renewableSharePercent": {
+        "calculationMethod": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "locationBased",
+            "marketBased"
+          ],
+          "description": "Rapporteringsmetode for Scope 2 (location- eller market-based)."
+        },
+        "documentationQualityPercent": {
           "type": [
             "number",
             "null"
           ],
           "minimum": 0,
           "maximum": 100,
-          "description": "Andel af strøm indkøbt som vedvarende energi (%)"
+          "description": "Vurdering af dokumentationskvalitet i procent."
+        },
+        "documentationFileName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 200,
+          "description": "Navn på fil med dokumentation (fx elregning)."
         }
       },
       "additionalProperties": false

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -70,11 +70,20 @@ export const a4InputSchema = z
   })
   .strict()
 
+const documentationQualityPercentSchema = z.number().min(0).max(100).nullable()
+const documentationFileNameSchema = z.string().max(200).nullable()
+
+const b1EmissionFactorSources = ['landefaktor', 'residualMix'] as const
+const b1CalculationMethods = ['locationBased', 'marketBased'] as const
+
 export const b1InputSchema = z
   .object({
-    electricityConsumptionKwh: z.number().min(0).nullable(),
+    consumptionKwh: z.number().min(0).nullable(),
+    emissionFactorSource: z.enum(b1EmissionFactorSources).nullable(),
     emissionFactorKgPerKwh: z.number().min(0).nullable(),
-    renewableSharePercent: z.number().min(0).max(100).nullable()
+    calculationMethod: z.enum(b1CalculationMethods).nullable(),
+    documentationQualityPercent: documentationQualityPercentSchema,
+    documentationFileName: documentationFileNameSchema
   })
   .strict()
 

--- a/packages/tooling/src/csv-to-formula-map.ts
+++ b/packages/tooling/src/csv-to-formula-map.ts
@@ -4,8 +4,7 @@
 import { readFile } from 'node:fs/promises'
 
 const formulaOverrides: Record<string, string> = {
-  B1:
-    'B1 = (electricityConsumptionKwh * emissionFactorKgPerKwh) - (electricityConsumptionKwh * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.9)',
+  B1: 'B1 = consumptionKwh * emissionFactorKgPerKwh',
   B2:
     'B2 = ((heatConsumptionKwh - recoveredHeatKwh) * emissionFactorKgPerKwh) - ((heatConsumptionKwh - recoveredHeatKwh) * emissionFactorKgPerKwh * renewableSharePercent/100 * 0.85)',
   B3:

--- a/packages/tooling/src/csv-to-schema.ts
+++ b/packages/tooling/src/csv-to-schema.ts
@@ -13,21 +13,36 @@ const b1Override = {
   title: 'B1Input',
   description: 'Scope 2 elforbrug',
   properties: {
-    electricityConsumptionKwh: {
+    consumptionKwh: {
       type: ['number', 'null'],
       minimum: 0,
-      description: 'Årligt elforbrug (kWh)'
+      description: 'Indkøbt elektricitet i kWh.'
+    },
+    emissionFactorSource: {
+      type: ['string', 'null'],
+      enum: ['landefaktor', 'residualMix', null],
+      description: 'Kilde til emissionsfaktor (landefaktor eller residualmix).'
     },
     emissionFactorKgPerKwh: {
       type: ['number', 'null'],
       minimum: 0,
-      description: 'Emissionsfaktor (kg CO2e pr. kWh)'
+      description: 'Emissionsfaktor i kg CO2e pr. kWh.'
     },
-    renewableSharePercent: {
+    calculationMethod: {
+      type: ['string', 'null'],
+      enum: ['locationBased', 'marketBased', null],
+      description: 'Valgt beregningsmetode for Scope 2.'
+    },
+    documentationQualityPercent: {
       type: ['number', 'null'],
       minimum: 0,
       maximum: 100,
-      description: 'Andel af strøm indkøbt som vedvarende energi (%)'
+      description: 'Dokumentationskvalitet i procent.'
+    },
+    documentationFileName: {
+      type: ['string', 'null'],
+      maxLength: 200,
+      description: 'Filnavn for dokumentation (fx elregning).'
     }
   },
   additionalProperties: false


### PR DESCRIPTION
## Summary
- align the B1 Zod and JSON schema with the new electricity inputs (consumption, factor source, calculation method, documentation metadata)
- refresh the B1 calculation, wizard step, tooling overrides, and formula map to reflect the simplified kWh × factor computation
- document the new workflow in the B1 runbook and adjust module tests to cover the revised logic

## Testing
- pnpm --filter @org/shared test

------
https://chatgpt.com/codex/tasks/task_e_68de43c6f24083258ab22a08c0111ccd