### PR TITLE
Update scope 1-2 wizard forms to match new inputs

### DIFF
--- a/apps/web/features/wizard/steps/A1.tsx
+++ b/apps/web/features/wizard/steps/A1.tsx
@@ -1,5 +1,5 @@
 /**
- * Wizardtrin for modul A1 – stationær forbrænding.
+ * Wizardtrin for modul A1 – stationære forbrændingskilder.
  */
 'use client'
 
@@ -10,12 +10,28 @@ import { a1FuelConfigurations, a1FuelOptions, runA1 } from '@org/shared'
 
 import type { WizardStepProps } from './StepTemplate'
 
-type FuelRow = NonNullable<A1Input['fuelConsumptions']>[number]
-type FuelFieldKey = 'quantity' | 'emissionFactorKgPerUnit' | 'documentationQualityPercent'
+const EMISSION_FACTOR_SOURCE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'standard', label: 'Standardfaktor fra database' },
+  { value: 'leverandor', label: 'Leverandørdata' }
+]
+
+type BaseFuelRow = NonNullable<A1Input['fuelConsumptions']>[number]
+
+type FuelRow = BaseFuelRow & {
+  energyContentMjPerUnit?: number | null
+  emissionFactorSource?: string | null
+  documentationFileName?: string | null
+}
 
 const EMPTY_A1: A1Input = {
   fuelConsumptions: []
 }
+
+const UNIT_OPTIONS: Array<{ value: BaseFuelRow['unit']; label: string }> = [
+  { value: 'liter', label: 'Liter' },
+  { value: 'Nm³', label: 'Nm³' },
+  { value: 'kg', label: 'Kilogram' }
+]
 
 function createDefaultRow(fuelType: keyof typeof a1FuelConfigurations = 'naturgas'): FuelRow {
   const config = a1FuelConfigurations[fuelType]
@@ -24,26 +40,41 @@ function createDefaultRow(fuelType: keyof typeof a1FuelConfigurations = 'naturga
     unit: config.defaultUnit,
     quantity: null,
     emissionFactorKgPerUnit: config.defaultEmissionFactorKgPerUnit,
-    documentationQualityPercent: 100
+    documentationQualityPercent: 100,
+    energyContentMjPerUnit: config.energyContentMjPerUnit,
+    emissionFactorSource: 'standard',
+    documentationFileName: null
   }
 }
 
-const UNIT_OPTIONS: Array<{ value: FuelRow['unit']; label: string }> = [
-  { value: 'liter', label: 'Liter' },
-  { value: 'Nm³', label: 'Nm³' },
-  { value: 'kg', label: 'Kilogram' }
-]
+function parseNumber(value: string): number | null {
+  const normalised = value.replace(',', '.')
+  if (normalised.trim() === '') {
+    return null
+  }
+  const parsed = Number.parseFloat(normalised)
+  return Number.isFinite(parsed) ? parsed : null
+}
 
 export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.A1 as A1Input | undefined) ?? EMPTY_A1
-  const rows = current.fuelConsumptions ?? []
+  const stored = (state.A1 as { fuelConsumptions?: FuelRow[] } | undefined) ?? EMPTY_A1
+  const rows = (stored.fuelConsumptions ?? []) as FuelRow[]
 
   const preview = useMemo<ModuleResult>(() => {
-    return runA1({ A1: current } as ModuleInput)
-  }, [current])
+    const calculationRows: NonNullable<A1Input['fuelConsumptions']> = rows.map(
+      ({ fuelType, unit, quantity, emissionFactorKgPerUnit, documentationQualityPercent }) => ({
+        fuelType,
+        unit,
+        quantity,
+        emissionFactorKgPerUnit,
+        documentationQualityPercent
+      })
+    )
+    return runA1({ A1: { fuelConsumptions: calculationRows } as A1Input } as ModuleInput)
+  }, [rows])
 
   const updateRows = (nextRows: FuelRow[]) => {
-    onChange('A1', { fuelConsumptions: nextRows })
+    onChange('A1', { fuelConsumptions: nextRows as unknown as A1Input['fuelConsumptions'] })
   }
 
   const handleAddRow = () => {
@@ -51,8 +82,7 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
   }
 
   const handleRemoveRow = (index: number) => () => {
-    const next = rows.filter((_, rowIndex) => rowIndex !== index)
-    updateRows(next)
+    updateRows(rows.filter((_, rowIndex) => rowIndex !== index))
   }
 
   const handleFuelTypeChange = (index: number) => (event: ChangeEvent<HTMLSelectElement>) => {
@@ -64,37 +94,85 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
       unit: config.defaultUnit,
       quantity: existing?.quantity ?? null,
       emissionFactorKgPerUnit: config.defaultEmissionFactorKgPerUnit,
-      documentationQualityPercent: existing?.documentationQualityPercent ?? 100
+      documentationQualityPercent: existing?.documentationQualityPercent ?? 100,
+      energyContentMjPerUnit: config.energyContentMjPerUnit,
+      emissionFactorSource: 'standard',
+      documentationFileName: existing?.documentationFileName ?? null
     }
-    const nextRows = rows.map((row, rowIndex) => (rowIndex === index ? nextRow : row))
-    updateRows(nextRows)
+    updateRows(rows.map((row, rowIndex) => (rowIndex === index ? nextRow : row)))
   }
 
   const handleUnitChange = (index: number) => (event: ChangeEvent<HTMLSelectElement>) => {
     const nextUnit = event.target.value as FuelRow['unit']
-    const nextRows = rows.map((row, rowIndex) =>
-      rowIndex === index
-        ? {
-            ...row,
-            unit: nextUnit
-          }
-        : row
+    updateRows(
+      rows.map((row, rowIndex) =>
+        rowIndex === index
+          ? {
+              ...row,
+              unit: nextUnit
+            }
+          : row
+      )
     )
-    updateRows(nextRows)
   }
 
-  const handleFieldChange = (index: number, field: FuelFieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const nextRows = rows.map((row, rowIndex) =>
-      rowIndex === index
-        ? {
-            ...row,
-            [field]: Number.isFinite(parsed) ? parsed : null
-          }
-        : row
+  const handleNumericFieldChange = (index: number, field: keyof BaseFuelRow) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const parsed = parseNumber(event.target.value)
+      updateRows(
+        rows.map((row, rowIndex) =>
+          rowIndex === index
+            ? {
+                ...row,
+                [field]: parsed
+              }
+            : row
+        )
+      )
+    }
+
+  const handleEmissionFactorSourceChange = (index: number) => (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    const row = rows[index]
+    const config = a1FuelConfigurations[row.fuelType]
+    updateRows(
+      rows.map((existing, rowIndex) =>
+        rowIndex === index
+          ? {
+              ...existing,
+              emissionFactorSource: value,
+              emissionFactorKgPerUnit: value === 'standard' ? config.defaultEmissionFactorKgPerUnit : existing.emissionFactorKgPerUnit
+            }
+          : existing
+      )
     )
-    updateRows(nextRows)
+  }
+
+  const handleFileChange = (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    updateRows(
+      rows.map((row, rowIndex) =>
+        rowIndex === index
+          ? {
+              ...row,
+              documentationFileName: file ? file.name : null
+            }
+          : row
+      )
+    )
+  }
+
+  const handleClearFile = (index: number) => () => {
+    updateRows(
+      rows.map((row, rowIndex) =>
+        rowIndex === index
+          ? {
+              ...row,
+              documentationFileName: null
+            }
+          : row
+      )
+    )
   }
 
   const hasRows = rows.length > 0
@@ -104,8 +182,8 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
       <header style={{ display: 'grid', gap: '0.5rem' }}>
         <h2>A1 – Scope 1 stationære forbrændingskilder</h2>
         <p style={{ margin: 0 }}>
-          Registrér brændselsforbrug for kedler, ovne og generatorer. Vælg brændstoftype, angiv mængde og juster
-          emissionsfaktoren ved behov. Dokumentationskvalitet bruges til at fremhæve rækker med lav datakvalitet.
+          Registrér brændselsforbrug for kedler, ovne og generatorer. Vælg brændstoftype, angiv mængde, se
+          energiindhold og vælg emissionsfaktor. Dokumentationskvalitet og bilag hjælper med revision.
         </p>
       </header>
 
@@ -133,6 +211,7 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
           <div style={{ display: 'grid', gap: '1rem' }}>
             {rows.map((row, index) => {
               const fuelConfig = a1FuelConfigurations[row.fuelType]
+              const optionMeta = a1FuelOptions.find((option) => option.value === row.fuelType)
               return (
                 <article
                   key={`fuel-row-${index}`}
@@ -176,7 +255,7 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
                     </select>
                   </label>
 
-                  <div style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+                  <div style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))' }}>
                     <label style={{ display: 'grid', gap: '0.25rem' }}>
                       <span>Mængde</span>
                       <input
@@ -186,7 +265,7 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
                         step="any"
                         value={row.quantity ?? ''}
                         placeholder={`0 (${fuelConfig.defaultUnit})`}
-                        onChange={handleFieldChange(index, 'quantity')}
+                        onChange={handleNumericFieldChange(index, 'quantity')}
                         style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #c8d2cf' }}
                       />
                     </label>
@@ -207,14 +286,41 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
                     </label>
 
                     <label style={{ display: 'grid', gap: '0.25rem' }}>
-                      <span>Emissionsfaktor (kg CO₂e/enhed)</span>
+                      <span>Energiindhold</span>
+                      <input
+                        type="number"
+                        value={row.energyContentMjPerUnit ?? optionMeta?.energyContentMjPerUnit ?? ''}
+                        readOnly
+                        style={{
+                          padding: '0.5rem',
+                          borderRadius: '0.5rem',
+                          border: '1px solid #c8d2cf',
+                          background: '#eef3f1'
+                        }}
+                      />
+                      <span style={{ fontSize: '0.8rem', color: '#5f6f6a' }}>MJ per {row.unit}</span>
+                    </label>
+
+                    <label style={{ display: 'grid', gap: '0.25rem' }}>
+                      <span>Emissionsfaktor</span>
+                      <select
+                        value={row.emissionFactorSource ?? 'standard'}
+                        onChange={handleEmissionFactorSourceChange(index)}
+                        style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #c8d2cf' }}
+                      >
+                        {EMISSION_FACTOR_SOURCE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
                       <input
                         type="number"
                         inputMode="decimal"
                         min={0}
                         step="any"
                         value={row.emissionFactorKgPerUnit ?? ''}
-                        onChange={handleFieldChange(index, 'emissionFactorKgPerUnit')}
+                        onChange={handleNumericFieldChange(index, 'emissionFactorKgPerUnit')}
                         style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #c8d2cf' }}
                       />
                       <span style={{ fontSize: '0.8rem', color: '#5f6f6a' }}>
@@ -231,25 +337,49 @@ export function A1Step({ state, onChange }: WizardStepProps): JSX.Element {
                         max={100}
                         step="any"
                         value={row.documentationQualityPercent ?? ''}
-                        onChange={handleFieldChange(index, 'documentationQualityPercent')}
+                        onChange={handleNumericFieldChange(index, 'documentationQualityPercent')}
                         style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #c8d2cf' }}
                       />
                     </label>
+                  </div>
+
+                  <div style={{ display: 'grid', gap: '0.35rem' }}>
+                    <label style={{ fontWeight: 600 }}>Dokumentation</label>
+                    <input
+                      type="file"
+                      onChange={handleFileChange(index)}
+                      style={{
+                        padding: '0.45rem',
+                        borderRadius: '0.5rem',
+                        border: '1px solid #c8d2cf',
+                        background: '#f6f9f8'
+                      }}
+                    />
+                    {row.documentationFileName ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
+                        <span>{row.documentationFileName}</span>
+                        <button
+                          type="button"
+                          onClick={handleClearFile(index)}
+                          style={{ border: 'none', background: 'transparent', color: '#b4231f', cursor: 'pointer' }}
+                        >
+                          Fjern
+                        </button>
+                      </div>
+                    ) : null}
                   </div>
                 </article>
               )
             })}
           </div>
         ) : (
-          <p style={{ margin: 0, color: '#5f6f6a' }}>
-            Tilføj mindst én brændselslinje for at beregne Scope 1-emissioner.
-          </p>
+          <p style={{ margin: 0, color: '#5f6f6a' }}>Tilføj mindst én brændselslinje for at beregne Scope 1-emissioner.</p>
         )}
       </section>
 
       <section style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}>
         <h3 style={{ margin: 0 }}>Estimat</h3>
-        {preview.trace.some((line) => line.startsWith('entry[')) ? (
+        {rows.length > 0 && preview.trace.some((line) => line.startsWith('entry[')) ? (
           <div style={{ display: 'grid', gap: '0.5rem' }}>
             <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
               {preview.value} {preview.unit}

--- a/apps/web/features/wizard/steps/B1.tsx
+++ b/apps/web/features/wizard/steps/B1.tsx
@@ -1,146 +1,102 @@
 /**
- * Wizardtrin for modul B1.
+ * Wizardtrin for modul B1 – elforbrug.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B1Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B1Input } from '@org/shared'
 import { runB1 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B1Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B1FormState = B1Input & {
+  emissionFactorSource?: string | null
+  calculationMethod?: 'locationBased' | 'marketBased' | null
+  documentationQualityPercent?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'electricityConsumptionKwh',
-    label: 'Årligt elforbrug',
-    description: 'Samlet forbrug for organisationen i kWh.',
-    unit: 'kWh'
-  },
-  {
-    key: 'emissionFactorKgPerKwh',
-    label: 'Emissionsfaktor',
-    description: 'Kg CO2e pr. kWh i leverandørens deklaration.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'renewableSharePercent',
-    label: 'Vedvarende andel',
-    description: 'Andel af strøm indkøbt som certificeret vedvarende energi.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B1: B1Input = {
+const EMPTY_B1: B1FormState = {
   electricityConsumptionKwh: null,
   emissionFactorKgPerKwh: null,
-  renewableSharePercent: null
+  renewableSharePercent: null,
+  emissionFactorSource: null,
+  calculationMethod: null,
+  documentationQualityPercent: null,
+  documentationFileName: null
 }
 
-export function B1Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.B1 as B1Input | undefined) ?? EMPTY_B1
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB1({ B1: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B1Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B1Step = createConfiguredModuleStep<'B1', B1FormState>({
+  moduleId: 'B1',
+  title: 'B1 – Scope 2 elforbrug',
+  description:
+    'Indtast organisationens indkøbte elforbrug og vælg hvilken emissionsfaktor der skal danne grundlag for beregningen.',
+  emptyState: EMPTY_B1,
+  fields: [
+    {
+      type: 'number',
+      key: 'electricityConsumptionKwh',
+      label: 'Forbrug',
+      unit: 'kWh',
+      description: 'Samlet indkøbt elektricitet i den valgte periode.'
+    },
+    {
+      type: 'select',
+      key: 'emissionFactorSource',
+      label: 'Emissionsfaktor',
+      description: 'Vælg landefaktor eller residualfaktor fra database eller leverandør.',
+      helperText: 'Valget udfylder feltet for emissionsfaktor nedenfor, som altid kan justeres manuelt.',
+      options: [
+        {
+          value: 'dk-standard',
+          label: 'Danmark – standardfaktor (0,233 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.233 }
+        },
+        {
+          value: 'dk-residual',
+          label: 'Danmark – residualfaktor (0,318 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU-gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.275 }
+        },
+        {
+          value: 'custom',
+          label: 'Egen leverandørdata',
+          derived: {}
+        }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'emissionFactorKgPerKwh',
+      label: 'Valgt emissionsfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Automatisk udfyldt fra dropdown men kan erstattes med leverandørdata.'
+    },
+    {
+      type: 'select',
+      key: 'calculationMethod',
+      label: 'Beregningsmetode',
+      description: 'Angiv om rapporteringen sker efter location-based eller market-based metode.',
+      options: [
+        { value: 'locationBased', label: 'Location based' },
+        { value: 'marketBased', label: 'Market based' }
+      ]
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af hvor sikker dokumentationen er for indtastet data.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload elregning eller måleraflæsning som bilag.'
     }
-    onChange('B1', next)
-  }
-
-  const hasData = preview.trace.some((line) => line.includes('grossEmissionsKg')) &&
-    (current.electricityConsumptionKwh != null ||
-      current.emissionFactorKgPerKwh != null ||
-      current.renewableSharePercent != null)
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B1 – Scope 2 elforbrug</h2>
-        <p>
-          Indtast data for organisationens elforbrug. Resultatet beregner nettoemissionen efter
-          fradrag for vedvarende indkøb.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                min={0}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}>
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
-              {preview.value} {preview.unit}
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB1
+})

--- a/apps/web/features/wizard/steps/B10.tsx
+++ b/apps/web/features/wizard/steps/B10.tsx
@@ -1,182 +1,86 @@
 /**
- * Wizardtrin for modul B10 – virtuelle PPA-leverancer.
+ * Wizardtrin for modul B10 – virtuel PPA.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B10Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B10Input } from '@org/shared'
 import { runB10 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B10Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B10FormState = B10Input & {
+  residualFactorSource?: string | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'ppaSettledKwh',
-    label: 'PPA-kontrakteret vedvarende el',
-    description: 'Årlig mængde elektricitet der finansielt afregnes gennem den virtuelle PPA.',
-    unit: 'kWh',
-    placeholder: '10000'
-  },
-  {
-    key: 'matchedConsumptionKwh',
-    label: 'Matchet forbrug',
-    description: 'Den del af virksomhedens elforbrug der forventes dækket af den virtuelle PPA.',
-    unit: 'kWh',
-    placeholder: '9500'
-  },
-  {
-    key: 'marketSettlementPercent',
-    label: 'Finansiel dækning',
-    description: 'Forventet settlement-dækning efter basisrisiko for den virtuelle aftale.',
-    unit: '%',
-    placeholder: '85'
-  },
-  {
-    key: 'residualEmissionFactorKgPerKwh',
-    label: 'Residual emissionsfaktor',
-    description: 'Kg CO2e pr. kWh for den residuale elmix der afløses.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'documentationQualityPercent',
-    label: 'Dokumentationskvalitet',
-    description: 'Forventet andel af dokumentationen der godkendes ved revision.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B10: B10Input = {
+const EMPTY_B10: B10FormState = {
   ppaSettledKwh: null,
   matchedConsumptionKwh: null,
   marketSettlementPercent: null,
   residualEmissionFactorKgPerKwh: null,
-  documentationQualityPercent: null
+  documentationQualityPercent: null,
+  residualFactorSource: null,
+  documentationFileName: null
 }
 
-export function B10Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B10'] as B10Input | undefined) ?? EMPTY_B10
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB10({ B10: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B10Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B10Step = createConfiguredModuleStep<'B10', B10FormState>({
+  moduleId: 'B10',
+  title: 'B10 – Virtuel PPA',
+  description: 'Registrér leverede mængder fra finansielle PPA-aftaler og tilhørende residualfaktor.',
+  emptyState: EMPTY_B10,
+  fields: [
+    {
+      type: 'number',
+      key: 'ppaSettledKwh',
+      label: 'PPA leveret kWh',
+      unit: 'kWh',
+      description: 'KWh omfattet af den finansielle afregning.'
+    },
+    {
+      type: 'number',
+      key: 'matchedConsumptionKwh',
+      label: 'Matchet kWh',
+      unit: 'kWh',
+      description: 'Elforbrug der matches mod PPA-leverancen.'
+    },
+    {
+      type: 'select',
+      key: 'residualFactorSource',
+      label: 'Residualfaktor',
+      description: 'Vælg hvilken residualfaktor der anvendes.',
+      options: [
+        {
+          value: 'dk-residual',
+          label: 'Danmark residual (0,318 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.275 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'residualEmissionFactorKgPerKwh',
+      label: 'Valgt residualfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan justeres hvis anden faktor benyttes.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af PPA-aftaler og afregninger.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload PPA-aftale og afregninger.'
     }
-    onChange('B10', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('settlementAdjustedKwh')) &&
-    (current.ppaSettledKwh != null ||
-      current.matchedConsumptionKwh != null ||
-      current.marketSettlementPercent != null ||
-      current.residualEmissionFactorKgPerKwh != null ||
-      current.documentationQualityPercent != null)
-
-  const valueColour = preview.value < 0 ? '#047857' : '#111827'
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B10 – Virtuel PPA for vedvarende el</h2>
-        <p>
-          Kortlæg finansielt afregnede PPA-aftaler, hvor basisrisiko reducerer den anvendelige mængde
-          vedvarende el. Modulet estimerer revisionsrobuste reduktioner efter settlement og
-          dokumentationskvalitet.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          const commonProps =
-            field.key === 'documentationQualityPercent'
-              ? { min: 0, max: 100 }
-              : field.key === 'marketSettlementPercent'
-                ? { min: 0, max: 100 }
-                : { min: 0 }
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                {...commonProps}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
-              {preview.value} {preview.unit}
-            </p>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
-              Negative tal angiver en reduktion i Scope 2-emissioner.
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>
-            Udfyld felterne for at se, hvordan den virtuelle PPA påvirker Scope 2-regnskabet.
-          </p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB10
+})

--- a/apps/web/features/wizard/steps/B11.tsx
+++ b/apps/web/features/wizard/steps/B11.tsx
@@ -1,183 +1,85 @@
 /**
- * Wizardtrin for modul B11 – time-matchede certifikater for vedvarende el.
+ * Wizardtrin for modul B11 – time-matchede certifikater.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B11Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B11Input } from '@org/shared'
 import { runB11 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B11Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B11FormState = B11Input & {
+  residualFactorSource?: string | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'certificatesRetiredKwh',
-    label: 'Annullerede certifikater',
-    description:
-      'Årlig mængde vedvarende energicertifikater der annulleres med henblik på virksomheden.',
-    unit: 'kWh',
-    placeholder: '12000'
-  },
-  {
-    key: 'matchedConsumptionKwh',
-    label: 'Matchet elforbrug',
-    description: 'Den del af virksomhedens elforbrug der dokumenteres med certifikaterne.',
-    unit: 'kWh',
-    placeholder: '11000'
-  },
-  {
-    key: 'timeCorrelationPercent',
-    label: 'Timekorrelation',
-    description: 'Andel af forbruget der er tidsmæssigt matchet mod certifikaterne.',
-    unit: '%',
-    placeholder: '85'
-  },
-  {
-    key: 'residualEmissionFactorKgPerKwh',
-    label: 'Residual emissionsfaktor',
-    description: 'Kg CO2e pr. kWh for det residuale elmix som certifikaterne erstatter.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'documentationQualityPercent',
-    label: 'Dokumentationskvalitet',
-    description: 'Forventet andel af dokumentationen der godkendes ved revision.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B11: B11Input = {
+const EMPTY_B11: B11FormState = {
   certificatesRetiredKwh: null,
   matchedConsumptionKwh: null,
   timeCorrelationPercent: null,
   residualEmissionFactorKgPerKwh: null,
-  documentationQualityPercent: null
+  documentationQualityPercent: null,
+  residualFactorSource: null,
+  documentationFileName: null
 }
 
-export function B11Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B11'] as B11Input | undefined) ?? EMPTY_B11
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB11({ B11: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B11Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B11Step = createConfiguredModuleStep<'B11', B11FormState>({
+  moduleId: 'B11',
+  title: 'B11 – Time-matchede certifikater',
+  description: 'Indtast data for certifikater der er matchet time for time med elforbruget.',
+  emptyState: EMPTY_B11,
+  fields: [
+    {
+      type: 'number',
+      key: 'certificatesRetiredKwh',
+      label: 'Forbrug dækket af certifikater',
+      unit: 'kWh',
+      description: 'Angiv kWh som dækkes af time-matchede certifikater.'
+    },
+    {
+      type: 'percent',
+      key: 'timeCorrelationPercent',
+      label: 'Time match andel',
+      description: 'Angiv hvor stor en andel af forbruget der er time-matchet.'
+    },
+    {
+      type: 'select',
+      key: 'residualFactorSource',
+      label: 'Residualfaktor',
+      description: 'Vælg residualfaktor anvendt ved beregningen.',
+      options: [
+        {
+          value: 'dk-residual',
+          label: 'Danmark residual (0,318 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.275 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'residualEmissionFactorKgPerKwh',
+      label: 'Valgt residualfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan ændres hvis anden faktor anvendes.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af certifikatlog og dokumentation.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload certifikatlog eller timeoversigt.'
     }
-    onChange('B11', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('timeAdjustedKwh')) &&
-    (current.certificatesRetiredKwh != null ||
-      current.matchedConsumptionKwh != null ||
-      current.timeCorrelationPercent != null ||
-      current.residualEmissionFactorKgPerKwh != null ||
-      current.documentationQualityPercent != null)
-
-  const valueColour = preview.value < 0 ? '#047857' : '#111827'
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B11 – Time-matchede certifikater for vedvarende el</h2>
-        <p>
-          Kortlæg certifikatporteføljer hvor garantier for oprindelse matches time for time mod
-          virksomhedens forbrug. Modulet estimerer revisionsrobuste reduktioner efter
-          timekorrelation og dokumentationskvalitet.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          const commonProps =
-            field.key === 'documentationQualityPercent'
-              ? { min: 0, max: 100 }
-              : field.key === 'timeCorrelationPercent'
-                ? { min: 0, max: 100 }
-                : { min: 0 }
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                {...commonProps}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
-              {preview.value} {preview.unit}
-            </p>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
-              Negative tal angiver en reduktion i Scope 2-emissioner.
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>
-            Udfyld felterne for at se, hvordan time-matchede certifikater påvirker Scope 2-regnskabet.
-          </p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB11
+})

--- a/apps/web/features/wizard/steps/B3.tsx
+++ b/apps/web/features/wizard/steps/B3.tsx
@@ -1,157 +1,79 @@
 /**
- * Wizardtrin for modul B3.
+ * Wizardtrin for modul B3 – køleforbrug.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B3Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B3Input } from '@org/shared'
 import { runB3 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B3Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B3FormState = B3Input & {
+  emissionFactorSource?: string | null
+  documentationQualityPercent?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'coolingConsumptionKwh',
-    label: 'Årligt køleforbrug',
-    description: 'Samlet køleenergi leveret fra forsyningen i kWh.',
-    unit: 'kWh'
-  },
-  {
-    key: 'recoveredCoolingKwh',
-    label: 'Genindvundet eller frikøling',
-    description: 'Køling fra genindvinding eller frikøling, der reducerer behovet.',
-    unit: 'kWh'
-  },
-  {
-    key: 'emissionFactorKgPerKwh',
-    label: 'Emissionsfaktor',
-    description: 'Kg CO2e pr. kWh i køleleverandørens miljødeklaration.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.030'
-  },
-  {
-    key: 'renewableSharePercent',
-    label: 'Vedvarende andel',
-    description: 'Andel af kølingen købt som certificeret vedvarende energi.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B3: B3Input = {
+const EMPTY_B3: B3FormState = {
   coolingConsumptionKwh: null,
   recoveredCoolingKwh: null,
   emissionFactorKgPerKwh: null,
-  renewableSharePercent: null
+  renewableSharePercent: null,
+  emissionFactorSource: null,
+  documentationQualityPercent: null,
+  documentationFileName: null
 }
 
-export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.B3 as B3Input | undefined) ?? EMPTY_B3
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB3({ B3: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B3Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B3Step = createConfiguredModuleStep<'B3', B3FormState>({
+  moduleId: 'B3',
+  title: 'B3 – Scope 2 køleforbrug',
+  description: 'Angiv købt fjernkøling og tilhørende emissionsfaktor.',
+  emptyState: EMPTY_B3,
+  fields: [
+    {
+      type: 'number',
+      key: 'coolingConsumptionKwh',
+      label: 'Forbrug',
+      unit: 'kWh',
+      description: 'Total indkøbt fjernkøling i perioden.'
+    },
+    {
+      type: 'select',
+      key: 'emissionFactorSource',
+      label: 'Emissionsfaktor',
+      description: 'Vælg reference fra database eller leverandør. Justér tallet nedenfor ved behov.',
+      options: [
+        {
+          value: 'dk-kole-standard',
+          label: 'Standard fjernkøling (0,050 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.05 }
+        },
+        {
+          value: 'leverandor',
+          label: 'Leverandørdata',
+          derived: {}
+        }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'emissionFactorKgPerKwh',
+      label: 'Valgt emissionsfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Justér hvis leverandør har oplyst anden faktor.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af datakvalitet og usikkerhed.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload forbrugsopgørelse eller tilsvarende.'
     }
-    onChange('B3', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('netCoolingConsumptionKwh')) &&
-    (current.coolingConsumptionKwh != null ||
-      current.recoveredCoolingKwh != null ||
-      current.emissionFactorKgPerKwh != null ||
-      current.renewableSharePercent != null)
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B3 – Scope 2 køleforbrug</h2>
-        <p>
-          Indtast data for organisationens indkøbte køling. Beregningen korrigerer for frikøling/genindvinding og
-          dokumenteret vedvarende leverancer.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                min={0}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
-              {preview.value} {preview.unit}
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB3
+})

--- a/apps/web/features/wizard/steps/B4.tsx
+++ b/apps/web/features/wizard/steps/B4.tsx
@@ -1,157 +1,113 @@
 /**
- * Wizardtrin for modul B4.
+ * Wizardtrin for modul B4 – dampforbrug.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B4Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B4Input } from '@org/shared'
 import { runB4 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B4Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+const STEAM_UNIT_TO_KWH: Record<'kWh' | 'ton', number> = {
+  kWh: 1,
+  ton: 657
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'steamConsumptionKwh',
-    label: 'Årligt dampforbrug',
-    description: 'Samlet dampenergi leveret fra forsyningen i kWh.',
-    unit: 'kWh'
-  },
-  {
-    key: 'recoveredSteamKwh',
-    label: 'Genindvundet damp eller kondensat',
-    description: 'Damp eller kondensat, der genanvendes og reducerer behovet.',
-    unit: 'kWh'
-  },
-  {
-    key: 'emissionFactorKgPerKwh',
-    label: 'Emissionsfaktor',
-    description: 'Kg CO2e pr. kWh i dampforsyningens miljødeklaration.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.090'
-  },
-  {
-    key: 'renewableSharePercent',
-    label: 'Vedvarende andel',
-    description: 'Andel af dampen købt som certificeret vedvarende energi.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
+export type B4FormState = B4Input & {
+  quantity?: number | null
+  quantityUnit?: 'kWh' | 'ton' | null
+  emissionFactorSource?: string | null
+  documentationQualityPercent?: number | null
+  documentationFileName?: string | null
+}
 
-const EMPTY_B4: B4Input = {
+const EMPTY_B4: B4FormState = {
   steamConsumptionKwh: null,
   recoveredSteamKwh: null,
   emissionFactorKgPerKwh: null,
-  renewableSharePercent: null
+  renewableSharePercent: null,
+  quantity: null,
+  quantityUnit: 'kWh',
+  emissionFactorSource: null,
+  documentationQualityPercent: null,
+  documentationFileName: null
 }
 
-export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B4'] as B4Input | undefined) ?? EMPTY_B4
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB4({ B4: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B4Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
-    }
-    onChange('B4', next)
+function toKwh(quantity: number | null, unit: 'kWh' | 'ton' | null | undefined): number | null {
+  if (quantity == null || Number.isNaN(quantity)) {
+    return null
   }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('netSteamConsumptionKwh')) &&
-    (current.steamConsumptionKwh != null ||
-      current.recoveredSteamKwh != null ||
-      current.emissionFactorKgPerKwh != null ||
-      current.renewableSharePercent != null)
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B4 – Scope 2 dampforbrug</h2>
-        <p>
-          Indtast data for organisationens indkøbte damp. Beregningen korrigerer for genanvendt damp og
-          dokumenteret vedvarende leverancer.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                min={0}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
-              {preview.value} {preview.unit}
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
-        )}
-      </section>
-    </form>
-  )
+  const safeUnit: 'kWh' | 'ton' = unit === 'ton' ? 'ton' : 'kWh'
+  return quantity * STEAM_UNIT_TO_KWH[safeUnit]
 }
+
+export const B4Step = createConfiguredModuleStep<'B4', B4FormState>({
+  moduleId: 'B4',
+  title: 'B4 – Scope 2 dampforbrug',
+  description:
+    'Registrér indkøbt damp. Angiv mængden i ton eller kWh og vælg relevant emissionsfaktor.',
+  emptyState: EMPTY_B4,
+  fields: [
+    {
+      type: 'select',
+      key: 'quantityUnit',
+      label: 'Enhed',
+      description: 'Vælg om mængden angives i ton eller kWh. Omregning sker automatisk.',
+      options: [
+        { value: 'kWh', label: 'kWh', derived: {} },
+        { value: 'ton', label: 'Ton damp', derived: {} }
+      ],
+      afterUpdate: ({ value, current }) => {
+        const unit = (value as 'kWh' | 'ton' | null) ?? 'kWh'
+        const amount = current.quantity ?? null
+        return { steamConsumptionKwh: toKwh(amount, unit) }
+      }
+    },
+    {
+      type: 'number',
+      key: 'quantity',
+      label: 'Mængde',
+      description: 'Angiv indkøbt damp i valgt enhed.',
+      helperText: '1 ton damp omregnes til ca. 657 kWh i beregningen.',
+      afterUpdate: ({ value, current }) => {
+        const amount = typeof value === 'number' ? value : null
+        const unit = (current.quantityUnit as 'kWh' | 'ton' | null) ?? 'kWh'
+        return { steamConsumptionKwh: toKwh(amount, unit) }
+      }
+    },
+    {
+      type: 'select',
+      key: 'emissionFactorSource',
+      label: 'Emissionsfaktor',
+      description: 'Vælg standardfaktor eller leverandørdata.',
+      options: [
+        {
+          value: 'standard',
+          label: 'Standard damp (0,180 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.18 }
+        },
+        { value: 'leverandor', label: 'Leverandørdata', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'emissionFactorKgPerKwh',
+      label: 'Valgt emissionsfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan tilpasses ved alternative deklarationer.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af dokumentation.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload leverandørdata eller måleraflæsning.'
+    }
+  ],
+  runModule: runB4
+})

--- a/apps/web/features/wizard/steps/B5.tsx
+++ b/apps/web/features/wizard/steps/B5.tsx
@@ -1,158 +1,110 @@
 /**
- * Wizardtrin for modul B5.
+ * Wizardtrin for modul B5 – øvrige energileverancer.
  */
 'use client'
 
-import { useMemo, type ChangeEvent } from 'react'
-
-import type { B5Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B5Input } from '@org/shared'
 import { runB5 } from '@org/shared'
 
-import type { WizardStepProps } from './StepTemplate'
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldKey = keyof B5Input
-
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B5FormState = B5Input & {
+  energyType?: string | null
+  emissionFactorSource?: string | null
+  documentationQualityPercent?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'otherEnergyConsumptionKwh',
-    label: 'Årligt forbrug',
-    description: 'Samlet mængde indkøbt energi for den valgte leverance i kWh.',
-    unit: 'kWh'
-  },
-  {
-    key: 'recoveredEnergyKwh',
-    label: 'Genindvundet energi',
-    description: 'Energi der udnyttes fra processer eller genanvendelse og reducerer behovet.',
-    unit: 'kWh'
-  },
-  {
-    key: 'emissionFactorKgPerKwh',
-    label: 'Emissionsfaktor',
-    description: 'Kg CO2e pr. kWh ifølge leverandørens miljødeklaration.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.075'
-  },
-  {
-    key: 'renewableSharePercent',
-    label: 'Vedvarende andel',
-    description: 'Andel dokumenteret som vedvarende energi for leverancen.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B5: B5Input = {
+const EMPTY_B5: B5FormState = {
   otherEnergyConsumptionKwh: null,
   recoveredEnergyKwh: null,
   emissionFactorKgPerKwh: null,
-  renewableSharePercent: null
+  renewableSharePercent: null,
+  energyType: null,
+  emissionFactorSource: null,
+  documentationQualityPercent: null,
+  documentationFileName: null
 }
 
-export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.B5 as B5Input | undefined) ?? EMPTY_B5
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB5({ B5: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B5Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B5Step = createConfiguredModuleStep<'B5', B5FormState>({
+  moduleId: 'B5',
+  title: 'B5 – Øvrige indkøbte energiformer',
+  description: 'Indtast andre energileverancer såsom fjern damp, trykluft eller lignende.',
+  emptyState: EMPTY_B5,
+  fields: [
+    {
+      type: 'select',
+      key: 'energyType',
+      label: 'Energitype',
+      description: 'Vælg den type energi der er købt ind.',
+      options: [
+        {
+          value: 'trykluft',
+          label: 'Trykluft',
+          derived: { emissionFactorKgPerKwh: 0.12 }
+        },
+        {
+          value: 'procesvarme',
+          label: 'Procesvarme',
+          derived: { emissionFactorKgPerKwh: 0.18 }
+        },
+        {
+          value: 'andet',
+          label: 'Andet',
+          derived: {}
+        }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'otherEnergyConsumptionKwh',
+      label: 'Mængde',
+      unit: 'kWh',
+      description: 'Angiv mængde i kWh eller konverter til kWh fra anden enhed.'
+    },
+    {
+      type: 'select',
+      key: 'emissionFactorSource',
+      label: 'Emissionsfaktor',
+      description: 'Vælg eller juster emissionsfaktor for den valgte energitype.',
+      options: [
+        {
+          value: 'standard-0.12',
+          label: 'Standard (0,120 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.12 }
+        },
+        {
+          value: 'standard-0.18',
+          label: 'Standard (0,180 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.18 }
+        },
+        {
+          value: 'custom',
+          label: 'Anden faktor',
+          derived: {}
+        }
+      ],
+      helperText: 'Feltet nedenfor opdateres automatisk og kan manuelt justeres.'
+    },
+    {
+      type: 'number',
+      key: 'emissionFactorKgPerKwh',
+      label: 'Valgt emissionsfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Angiv den faktiske emissionsfaktor hvis den afviger fra standard.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af dokumentationsgrundlaget for energidata.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload dokumentation for energileverancen.'
     }
-    onChange('B5', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('netOtherEnergyConsumptionKwh')) &&
-    (current.otherEnergyConsumptionKwh != null ||
-      current.recoveredEnergyKwh != null ||
-      current.emissionFactorKgPerKwh != null ||
-      current.renewableSharePercent != null)
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B5 – Scope 2 øvrige energileverancer</h2>
-        <p>
-          Indtast data for energileverancer som ikke dækkes af el, varme, køling eller damp. Beregningen korrigerer for
-          genindvundet energi og dokumenteret vedvarende andel.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                min={0}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
-              {preview.value} {preview.unit}
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB5
+})

--- a/apps/web/features/wizard/steps/B6.tsx
+++ b/apps/web/features/wizard/steps/B6.tsx
@@ -3,156 +3,84 @@
  */
 'use client'
 
-import { useMemo, type ChangeEvent } from 'react'
-
-import type { B6Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B6Input } from '@org/shared'
 import { runB6 } from '@org/shared'
 
-import type { WizardStepProps } from './StepTemplate'
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldKey = keyof B6Input
-
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B6FormState = B6Input & {
+  emissionFactorSource?: string | null
+  documentationQualityPercent?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'electricitySuppliedKwh',
-    label: 'Årligt elforbrug (basis)',
-    description: 'Den leverede mængde elektricitet som nettabbet beregnes ud fra (kWh).',
-    unit: 'kWh'
-  },
-  {
-    key: 'gridLossPercent',
-    label: 'Nettab',
-    description: 'Forventet transmissions- og distributionstab angivet i procent af forbruget.',
-    unit: '%',
-    placeholder: '0-20'
-  },
-  {
-    key: 'emissionFactorKgPerKwh',
-    label: 'Emissionsfaktor',
-    description: 'Kg CO2e pr. tabt kWh elektricitet. Typisk samme faktor som for elforbrug.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'renewableSharePercent',
-    label: 'Vedvarende dækning',
-    description: 'Andel af tabet der dokumenteres dækket af vedvarende energi gennem garantier eller certifikater.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B6: B6Input = {
+const EMPTY_B6: B6FormState = {
   electricitySuppliedKwh: null,
   gridLossPercent: null,
   emissionFactorKgPerKwh: null,
-  renewableSharePercent: null
+  renewableSharePercent: null,
+  emissionFactorSource: null,
+  documentationQualityPercent: null,
+  documentationFileName: null
 }
 
-export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state.B6 as B6Input | undefined) ?? EMPTY_B6
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB6({ B6: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B6Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B6Step = createConfiguredModuleStep<'B6', B6FormState>({
+  moduleId: 'B6',
+  title: 'B6 – Nettab i elnettet',
+  description: 'Indtast elforbrug der påvirkes af nettab og vælg passende emissionsfaktor.',
+  emptyState: EMPTY_B6,
+  fields: [
+    {
+      type: 'number',
+      key: 'electricitySuppliedKwh',
+      label: 'Indkøbt elektricitet',
+      unit: 'kWh',
+      description: 'Købte kWh som transporteres gennem eget net.'
+    },
+    {
+      type: 'percent',
+      key: 'gridLossPercent',
+      label: 'Nettab',
+      description: 'Angiv tab i nettet i procent.'
+    },
+    {
+      type: 'select',
+      key: 'emissionFactorSource',
+      label: 'Emissionsfaktor',
+      description: 'Vælg relevant faktor for transmissions- og distributionstab.',
+      options: [
+        {
+          value: 'dk-standard',
+          label: 'Danmark – standard (0,233 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.233 }
+        },
+        {
+          value: 'residual',
+          label: 'Residualfaktor (0,318 kg CO₂e/kWh)',
+          derived: { emissionFactorKgPerKwh: 0.318 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'emissionFactorKgPerKwh',
+      label: 'Valgt emissionsfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan justeres manuelt hvis anden faktor anvendes.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af data for nettab.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload net- og leverandørdokumentation.'
     }
-    onChange('B6', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('lossEnergyKwh')) &&
-    (current.electricitySuppliedKwh != null ||
-      current.gridLossPercent != null ||
-      current.emissionFactorKgPerKwh != null ||
-      current.renewableSharePercent != null)
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B6 – Scope 2 nettab i elnettet</h2>
-        <p>
-          Indtast data for transmission- og distributionstab for elektricitet. Resultatet estimerer emissionerne fra tabet og
-          reducerer for dokumenteret vedvarende dækning.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                min={0}
-                max={field.unit === '%' ? 100 : undefined}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}>
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
-              {preview.value} {preview.unit}
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet emission fra nettab.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB6
+})

--- a/apps/web/features/wizard/steps/B7.tsx
+++ b/apps/web/features/wizard/steps/B7.tsx
@@ -3,157 +3,83 @@
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B7Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B7Input } from '@org/shared'
 import { runB7 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B7Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B7FormState = B7Input & {
+  residualFactorSource?: string | null
+  certificateSharePercent?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'documentedRenewableKwh',
-    label: 'Dokumenteret vedvarende el',
-    description: 'Mængde el i kWh der er dækket af certifikater eller PPAs.',
-    unit: 'kWh',
-    placeholder: '10000'
-  },
-  {
-    key: 'residualEmissionFactorKgPerKwh',
-    label: 'Residual emissionsfaktor',
-    description: 'Kg CO2e pr. kWh for den residuale elmix der afløses.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'documentationQualityPercent',
-    label: 'Dokumentationskvalitet',
-    description: 'Andel af dokumentationen der forventes godkendt ved revision.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B7: B7Input = {
+const EMPTY_B7: B7FormState = {
   documentedRenewableKwh: null,
   residualEmissionFactorKgPerKwh: null,
-  documentationQualityPercent: null
+  documentationQualityPercent: null,
+  residualFactorSource: null,
+  certificateSharePercent: null,
+  documentationFileName: null
 }
 
-export function B7Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B7'] as B7Input | undefined) ?? EMPTY_B7
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB7({ B7: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B7Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B7Step = createConfiguredModuleStep<'B7', B7FormState>({
+  moduleId: 'B7',
+  title: 'B7 – Dokumenteret vedvarende el',
+  description: 'Angiv hvor meget vedvarende el der dokumenteres via certifikater og hvilke residualfaktorer der anvendes.',
+  emptyState: EMPTY_B7,
+  fields: [
+    {
+      type: 'number',
+      key: 'documentedRenewableKwh',
+      label: 'Dokumenteret kWh',
+      unit: 'kWh',
+      description: 'Mængde el dækket af certifikater eller garantier.'
+    },
+    {
+      type: 'percent',
+      key: 'certificateSharePercent',
+      label: 'Certifikatandel',
+      description: 'Procentdel af elforbruget der er certifikatdækket.'
+    },
+    {
+      type: 'select',
+      key: 'residualFactorSource',
+      label: 'Residualfaktor',
+      description: 'Vælg hvilken residualfaktor der anvendes i beregningen.',
+      options: [
+        {
+          value: 'dk-residual',
+          label: 'Danmark residual (0,318 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.275 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'residualEmissionFactorKgPerKwh',
+      label: 'Valgt residualfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan justeres manuelt hvis anden faktor benyttes.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af datakvalitet for certifikatdækningen.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload certifikater eller garantier for oprindelse.'
     }
-    onChange('B7', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('qualityAdjustedKwh')) &&
-    (current.documentedRenewableKwh != null ||
-      current.residualEmissionFactorKgPerKwh != null ||
-      current.documentationQualityPercent != null)
-
-  const valueColour = preview.value < 0 ? '#047857' : '#111827'
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B7 – Dokumenteret vedvarende el</h2>
-        <p>
-          Registrer certifikater, PPAs eller anden dokumenteret vedvarende el. Beregningen estimerer den
-          revisionsrobuste reduktion i Scope 2-udledninger.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          const commonProps =
-            field.key === 'documentationQualityPercent'
-              ? { min: 0, max: 100 }
-              : { min: 0 }
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                {...commonProps}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
-              {preview.value} {preview.unit}
-            </p>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
-              Negative tal angiver en reduktion i Scope 2-emissioner.
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se den dokumenterede reduktion.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB7
+})

--- a/apps/web/features/wizard/steps/B8.tsx
+++ b/apps/web/features/wizard/steps/B8.tsx
@@ -3,166 +3,93 @@
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B8Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B8Input } from '@org/shared'
 import { runB8 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B8Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B8FormState = B8Input & {
+  residualFactorSource?: string | null
+  selfConsumedKwh?: number | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'onSiteRenewableKwh',
-    label: 'Egenproduceret vedvarende el',
-    description: 'Total egenproduktion af vedvarende elektricitet i kWh.',
-    unit: 'kWh',
-    placeholder: '12000'
-  },
-  {
-    key: 'exportedRenewableKwh',
-    label: 'Eksporteret vedvarende el',
-    description: 'Andel af egenproduktionen der sælges eller leveres til nettet.',
-    unit: 'kWh',
-    placeholder: '0'
-  },
-  {
-    key: 'residualEmissionFactorKgPerKwh',
-    label: 'Residual emissionsfaktor',
-    description: 'Kg CO2e pr. kWh for den residuale elmix egenproduktionen afløser.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'documentationQualityPercent',
-    label: 'Dokumentationskvalitet',
-    description: 'Forventet andel af dokumentationen der bliver godkendt ved revision.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B8: B8Input = {
+const EMPTY_B8: B8FormState = {
   onSiteRenewableKwh: null,
   exportedRenewableKwh: null,
   residualEmissionFactorKgPerKwh: null,
-  documentationQualityPercent: null
+  documentationQualityPercent: null,
+  residualFactorSource: null,
+  selfConsumedKwh: null,
+  documentationFileName: null
 }
 
-export function B8Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B8'] as B8Input | undefined) ?? EMPTY_B8
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB8({ B8: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B8Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B8Step = createConfiguredModuleStep<'B8', B8FormState>({
+  moduleId: 'B8',
+  title: 'B8 – Egenproduceret vedvarende el',
+  description:
+    'Registrér egenproduktion, hvor meget der anvendes internt og hvor meget der eksporteres til nettet.',
+  emptyState: EMPTY_B8,
+  fields: [
+    {
+      type: 'number',
+      key: 'onSiteRenewableKwh',
+      label: 'Produceret vedvarende el',
+      unit: 'kWh',
+      description: 'Samlet produktion på matriklen i perioden.'
+    },
+    {
+      type: 'number',
+      key: 'selfConsumedKwh',
+      label: 'Egenanvendt vedvarende el',
+      unit: 'kWh',
+      description: 'Hvor meget af produktionen forbruges internt (information til dokumentation).'
+    },
+    {
+      type: 'number',
+      key: 'exportedRenewableKwh',
+      label: 'Eksporteret vedvarende el',
+      unit: 'kWh',
+      description: 'Mængde der sendes ud på nettet.'
+    },
+    {
+      type: 'select',
+      key: 'residualFactorSource',
+      label: 'Residualfaktor',
+      description: 'Vælg referencefaktor der anvendes til beregning af reduktion.',
+      options: [
+        {
+          value: 'dk-residual',
+          label: 'Danmark residual (0,318 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.275 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'residualEmissionFactorKgPerKwh',
+      label: 'Valgt residualfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan erstattes hvis anden faktor benyttes.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af dokumentation eller målerdata.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload målerdata eller inverterlog.'
     }
-    onChange('B8', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('netSelfConsumptionKwh')) &&
-    (current.onSiteRenewableKwh != null ||
-      current.exportedRenewableKwh != null ||
-      current.residualEmissionFactorKgPerKwh != null ||
-      current.documentationQualityPercent != null)
-
-  const valueColour = preview.value < 0 ? '#047857' : '#111827'
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B8 – Egenproduceret vedvarende el</h2>
-        <p>
-          Registrer egenproduceret vedvarende elektricitet og eventuel eksport. Modulet estimerer den
-          revisionsrobuste reduktion, når egenproduktionen afløser residual el.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          const commonProps =
-            field.key === 'documentationQualityPercent'
-              ? { min: 0, max: 100 }
-              : { min: 0 }
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                {...commonProps}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
-              {preview.value} {preview.unit}
-            </p>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
-              Negative tal angiver en reduktion i Scope 2-emissioner.
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se effekten af egenproduceret el.</p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB8
+})

--- a/apps/web/features/wizard/steps/B9.tsx
+++ b/apps/web/features/wizard/steps/B9.tsx
@@ -1,181 +1,86 @@
 /**
- * Wizardtrin for modul B9 – fysiske PPA-leverancer af vedvarende el.
+ * Wizardtrin for modul B9 – kontraktbaseret vedvarende el.
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
-import type { B9Input, ModuleInput, ModuleResult } from '@org/shared'
+import type { B9Input } from '@org/shared'
 import { runB9 } from '@org/shared'
-import type { WizardStepProps } from './StepTemplate'
 
-type FieldKey = keyof B9Input
+import { createConfiguredModuleStep } from './ConfiguredModuleStep'
 
-type FieldConfig = {
-  key: FieldKey
-  label: string
-  description: string
-  unit: string
-  placeholder?: string
+export type B9FormState = B9Input & {
+  residualFactorSource?: string | null
+  documentationFileName?: string | null
 }
 
-const FIELD_CONFIG: FieldConfig[] = [
-  {
-    key: 'ppaDeliveredKwh',
-    label: 'PPA-leveret vedvarende el',
-    description: 'Årlig mængde elektricitet leveret gennem den fysiske PPA.',
-    unit: 'kWh',
-    placeholder: '10000'
-  },
-  {
-    key: 'matchedConsumptionKwh',
-    label: 'Matchet forbrug',
-    description: 'Den del af virksomhedens elforbrug der dokumenteret dækkes af PPA’en.',
-    unit: 'kWh',
-    placeholder: '9500'
-  },
-  {
-    key: 'gridLossPercent',
-    label: 'Nettab',
-    description: 'Tab på transmissions- og distributionsnettet mellem producent og forbruger.',
-    unit: '%',
-    placeholder: '2'
-  },
-  {
-    key: 'residualEmissionFactorKgPerKwh',
-    label: 'Residual emissionsfaktor',
-    description: 'Kg CO2e pr. kWh for den residuale elmix som PPA’en afløser.',
-    unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
-  },
-  {
-    key: 'documentationQualityPercent',
-    label: 'Dokumentationskvalitet',
-    description: 'Forventet andel af dokumentationen der godkendes ved revision.',
-    unit: '%',
-    placeholder: '0-100'
-  }
-]
-
-const EMPTY_B9: B9Input = {
+const EMPTY_B9: B9FormState = {
   ppaDeliveredKwh: null,
   matchedConsumptionKwh: null,
   gridLossPercent: null,
   residualEmissionFactorKgPerKwh: null,
-  documentationQualityPercent: null
+  documentationQualityPercent: null,
+  residualFactorSource: null,
+  documentationFileName: null
 }
 
-export function B9Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B9'] as B9Input | undefined) ?? EMPTY_B9
-
-  const preview = useMemo<ModuleResult>(() => {
-    return runB9({ B9: current } as ModuleInput)
-  }, [current])
-
-  const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(',', '.')
-    const parsed = rawValue === '' ? null : Number.parseFloat(rawValue)
-    const next: B9Input = {
-      ...current,
-      [field]: Number.isFinite(parsed) ? parsed : null
+export const B9Step = createConfiguredModuleStep<'B9', B9FormState>({
+  moduleId: 'B9',
+  title: 'B9 – Kontraktbaseret vedvarende el',
+  description: 'Registrér mængder fra kontrakter uden fysisk match og vælg relevant residualfaktor.',
+  emptyState: EMPTY_B9,
+  fields: [
+    {
+      type: 'number',
+      key: 'ppaDeliveredKwh',
+      label: 'Kontrakteret kWh',
+      unit: 'kWh',
+      description: 'Mængde el der er aftalt i kontrakten.'
+    },
+    {
+      type: 'number',
+      key: 'matchedConsumptionKwh',
+      label: 'Leveret kWh',
+      unit: 'kWh',
+      description: 'Reelt leveret el der matches mod forbruget.'
+    },
+    {
+      type: 'select',
+      key: 'residualFactorSource',
+      label: 'Residualfaktor',
+      description: 'Vælg hvilken residualfaktor der anvendes til emissionsberegningen.',
+      options: [
+        {
+          value: 'dk-residual',
+          label: 'Danmark residual (0,318 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.318 }
+        },
+        {
+          value: 'eu-average',
+          label: 'EU gennemsnit (0,275 kg CO₂e/kWh)',
+          derived: { residualEmissionFactorKgPerKwh: 0.275 }
+        },
+        { value: 'custom', label: 'Anden faktor', derived: {} }
+      ]
+    },
+    {
+      type: 'number',
+      key: 'residualEmissionFactorKgPerKwh',
+      label: 'Valgt residualfaktor',
+      unit: 'kg CO₂e/kWh',
+      description: 'Kan justeres hvis der anvendes en anden faktor.'
+    },
+    {
+      type: 'percent',
+      key: 'documentationQualityPercent',
+      label: 'Dokumentationskvalitet',
+      description: 'Vurdering af kvaliteten af kontrakt- og leverancedata.'
+    },
+    {
+      type: 'file',
+      key: 'documentationFileName',
+      label: 'Dokumentation',
+      description: 'Upload kontrakter og leveranceopgørelser.'
     }
-    onChange('B9', next)
-  }
-
-  const hasData =
-    preview.trace.some((line) => line.includes('netMatchedKwh')) &&
-    (current.ppaDeliveredKwh != null ||
-      current.matchedConsumptionKwh != null ||
-      current.gridLossPercent != null ||
-      current.residualEmissionFactorKgPerKwh != null ||
-      current.documentationQualityPercent != null)
-
-  const valueColour = preview.value < 0 ? '#047857' : '#111827'
-
-  return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B9 – Fysisk PPA for vedvarende el</h2>
-        <p>
-          Kortlæg dokumenteret levering af vedvarende elektricitet via fysiske PPA-aftaler. Modulet
-          beregner den revisionsrobuste reduktion efter nettab og dokumentationskvalitet.
-        </p>
-      </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
-        {FIELD_CONFIG.map((field) => {
-          const value = current[field.key]
-          const commonProps =
-            field.key === 'documentationQualityPercent'
-              ? { min: 0, max: 100 }
-              : field.key === 'gridLossPercent'
-                ? { min: 0, max: 100 }
-                : { min: 0 }
-          return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
-                {field.label} ({field.unit})
-              </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
-              <input
-                type="number"
-                step="any"
-                value={value ?? ''}
-                placeholder={field.placeholder}
-                onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
-                {...commonProps}
-              />
-            </label>
-          )
-        })}
-      </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
-        {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: valueColour }}>
-              {preview.value} {preview.unit}
-            </p>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
-              Negative tal angiver en reduktion i Scope 2-emissioner.
-            </p>
-            <div>
-              <strong>Antagelser</strong>
-              <ul>
-                {preview.assumptions.map((assumption, index) => (
-                  <li key={index}>{assumption}</li>
-                ))}
-              </ul>
-            </div>
-            {preview.warnings.length > 0 && (
-              <div>
-                <strong>Advarsler</strong>
-                <ul>
-                  {preview.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <details>
-              <summary>Teknisk trace</summary>
-              <ul>
-                {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
-                    {line}
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-        ) : (
-          <p style={{ margin: 0 }}>
-            Udfyld felterne for at se, hvordan PPA-leveret vedvarende el påvirker Scope 2-regnskabet.
-          </p>
-        )}
-      </section>
-    </form>
-  )
-}
+  ],
+  runModule: runB9
+})

--- a/apps/web/features/wizard/steps/ConfiguredModuleStep.tsx
+++ b/apps/web/features/wizard/steps/ConfiguredModuleStep.tsx
@@ -1,0 +1,325 @@
+/**
+ * Helper til at bygge modultrin ud fra en feltkonfiguration.
+ */
+'use client'
+
+import { useId, useMemo } from 'react'
+import type { ChangeEvent } from 'react'
+import type { ModuleCalculator, ModuleId, ModuleInput, ModuleResult } from '@org/shared'
+import type { WizardStepComponent, WizardStepProps } from './StepTemplate'
+
+export type SelectOption<State extends Record<string, unknown>> = {
+  value: string
+  label: string
+  description?: string
+  derived?: Partial<State>
+}
+
+export type BaseField<State extends Record<string, unknown>> = {
+  key: keyof State & string
+  label: string
+  description?: string
+  helperText?: string
+  afterUpdate?: (context: { value: unknown; current: State }) => Partial<State> | void
+}
+
+export type NumberField<State extends Record<string, unknown>> = BaseField<State> & {
+  type: 'number'
+  unit?: string
+  placeholder?: string
+  min?: number
+  max?: number
+  step?: number | 'any'
+  readOnly?: boolean
+}
+
+export type PercentField<State extends Record<string, unknown>> = BaseField<State> & {
+  type: 'percent'
+  placeholder?: string
+}
+
+export type SelectField<State extends Record<string, unknown>> = BaseField<State> & {
+  type: 'select'
+  options: Array<SelectOption<State>>
+  placeholder?: string
+}
+
+export type FileField<State extends Record<string, unknown>> = BaseField<State> & {
+  type: 'file'
+  accept?: string
+}
+
+export type FieldDefinition<State extends Record<string, unknown>> =
+  | NumberField<State>
+  | PercentField<State>
+  | SelectField<State>
+  | FileField<State>
+
+export type ModuleStepConfig<Id extends ModuleId, State extends Record<string, unknown>> = {
+  moduleId: Id
+  title: string
+  description?: string
+  emptyState: State
+  fields: Array<FieldDefinition<State>>
+  runModule: ModuleCalculator
+}
+
+function normaliseNumber(rawValue: string): number | null {
+  const trimmed = rawValue.trim()
+  if (trimmed === '') {
+    return null
+  }
+  const normalised = trimmed.replace(',', '.')
+  const parsed = Number.parseFloat(normalised)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function createConfiguredModuleStep<
+  Id extends ModuleId,
+  State extends Record<string, unknown>
+>(config: ModuleStepConfig<Id, State>): WizardStepComponent {
+  return function ConfiguredModuleStep({ state, onChange }: WizardStepProps): JSX.Element {
+    const fieldIds = useId()
+
+    const current = useMemo(() => {
+      const stored = state[config.moduleId] as State | undefined
+      return { ...config.emptyState, ...(stored ?? {}) }
+    }, [state])
+
+    const preview = useMemo<ModuleResult>(() => {
+      return config.runModule({ [config.moduleId]: current } as ModuleInput)
+    }, [current])
+
+    const updateState = (patch: Partial<State>) => {
+      const next = { ...current, ...patch }
+      onChange(config.moduleId, next)
+    }
+
+    const renderField = (field: FieldDefinition<State>, index: number) => {
+      const commonLabel = (
+        <span style={{ fontWeight: 600 }}>
+          {field.label}
+          {'unit' in field && field.unit ? ` (${field.unit})` : null}
+        </span>
+      )
+
+      const description = field.description ? (
+        <span style={{ color: '#4a5c57', fontSize: '0.85rem' }}>{field.description}</span>
+      ) : null
+
+      const helper = field.helperText ? (
+        <span style={{ color: '#6b7d77', fontSize: '0.8rem' }}>{field.helperText}</span>
+      ) : null
+
+      if (field.type === 'number') {
+        const value = current[field.key] as number | null | undefined
+        const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+          const parsed = normaliseNumber(event.target.value)
+          const patch: Partial<State> = { [field.key]: parsed } as Partial<State>
+          const extra = field.afterUpdate?.({ value: parsed, current })
+          if (extra) {
+            Object.assign(patch, extra)
+          }
+          updateState(patch)
+        }
+        return (
+          <label key={`${fieldIds}-${index}`} style={{ display: 'grid', gap: '0.35rem' }}>
+            {commonLabel}
+            {description}
+            <input
+              type="number"
+              inputMode="decimal"
+              value={value ?? ''}
+              onChange={handleChange}
+              placeholder={field.placeholder}
+              min={field.min}
+              max={field.max}
+              step={field.step ?? 'any'}
+              readOnly={field.readOnly}
+              style={{ padding: '0.55rem', borderRadius: '0.5rem', border: '1px solid #c3cec9' }}
+            />
+            {helper}
+          </label>
+        )
+      }
+
+      if (field.type === 'percent') {
+        const value = current[field.key] as number | null | undefined
+        const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+          const parsed = normaliseNumber(event.target.value)
+          const patch: Partial<State> = { [field.key]: parsed } as Partial<State>
+          const extra = field.afterUpdate?.({ value: parsed, current })
+          if (extra) {
+            Object.assign(patch, extra)
+          }
+          updateState(patch)
+        }
+        return (
+          <label key={`${fieldIds}-${index}`} style={{ display: 'grid', gap: '0.35rem' }}>
+            {commonLabel}
+            {description}
+            <input
+              type="number"
+              inputMode="decimal"
+              value={value ?? ''}
+              onChange={handleChange}
+              placeholder={field.placeholder}
+              min={0}
+              max={100}
+              step="any"
+              style={{ padding: '0.55rem', borderRadius: '0.5rem', border: '1px solid #c3cec9' }}
+            />
+            {helper}
+          </label>
+        )
+      }
+
+      if (field.type === 'select') {
+        const value = (current[field.key] as string | null | undefined) ?? ''
+        const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+          const selectedValue = event.target.value
+          const option = field.options.find((candidate) => candidate.value === selectedValue)
+          const patch: Partial<State> = {
+            [field.key]: selectedValue === '' ? null : selectedValue
+          } as Partial<State>
+          if (option?.derived) {
+            Object.assign(patch, option.derived)
+          }
+          const extra = field.afterUpdate?.({
+            value: selectedValue === '' ? null : selectedValue,
+            current
+          })
+          if (extra) {
+            Object.assign(patch, extra)
+          }
+          updateState(patch)
+        }
+        return (
+          <label key={`${fieldIds}-${index}`} style={{ display: 'grid', gap: '0.35rem' }}>
+            {commonLabel}
+            {description}
+            <select
+              value={value}
+              onChange={handleChange}
+              style={{ padding: '0.55rem', borderRadius: '0.5rem', border: '1px solid #c3cec9' }}
+            >
+              <option value="">{field.placeholder ?? 'Vælg mulighed'}</option>
+              {field.options.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            {helper}
+          </label>
+        )
+      }
+
+      // file
+      const storedValue = (current[field.key] as string | null | undefined) ?? ''
+      const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        updateState({ [field.key]: file ? file.name : null } as Partial<State>)
+      }
+      const handleClear = () => {
+        updateState({ [field.key]: null } as Partial<State>)
+      }
+      return (
+        <div key={`${fieldIds}-${index}`} style={{ display: 'grid', gap: '0.35rem' }}>
+          <span style={{ fontWeight: 600 }}>{field.label}</span>
+          {description}
+          <input
+            type="file"
+            onChange={handleChange}
+            accept={field.accept}
+            style={{
+              padding: '0.45rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #c3cec9',
+              background: '#f6f9f8'
+            }}
+          />
+          {storedValue ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
+              <span>{storedValue}</span>
+              <button
+                type="button"
+                onClick={handleClear}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  color: '#a23b32',
+                  cursor: 'pointer'
+                }}
+              >
+                Fjern
+              </button>
+            </div>
+          ) : null}
+          {helper}
+        </div>
+      )
+    }
+
+    const hasAnyInput = Object.values(current).some((value) => value !== null && value !== undefined && value !== '')
+    const hasData = hasAnyInput && preview.trace.length > 0
+
+    return (
+      <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '50rem' }}>
+        <header style={{ display: 'grid', gap: '0.65rem' }}>
+          <h2 style={{ margin: 0 }}>{config.title}</h2>
+          {config.description ? <p style={{ margin: 0 }}>{config.description}</p> : null}
+        </header>
+
+        <section style={{ display: 'grid', gap: '1rem' }}>
+          {config.fields.map((field, index) => renderField(field, index))}
+        </section>
+
+        <section
+          style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
+        >
+          <h3 style={{ margin: 0 }}>Estimat</h3>
+          {hasData ? (
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+                {preview.value} {preview.unit}
+              </p>
+              {preview.assumptions.length > 0 ? (
+                <div>
+                  <strong>Antagelser</strong>
+                  <ul>
+                    {preview.assumptions.map((assumption, index) => (
+                      <li key={`assumption-${index}`}>{assumption}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {preview.warnings.length > 0 ? (
+                <div>
+                  <strong>Advarsler</strong>
+                  <ul>
+                    {preview.warnings.map((warning, index) => (
+                      <li key={`warning-${index}`}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <details>
+                <summary>Teknisk trace</summary>
+                <ul>
+                  {preview.trace.map((line, index) => (
+                    <li key={`trace-${index}`} style={{ fontFamily: 'monospace' }}>
+                      {line}
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </div>
+          ) : (
+            <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet emission.</p>
+          )}
+        </section>
+      </form>
+    )
+  }
+}

--- a/packages/shared/calculations/modules/runA1.ts
+++ b/packages/shared/calculations/modules/runA1.ts
@@ -8,22 +8,32 @@ export const a1FuelConfigurations = {
   naturgas: {
     label: 'Naturgas',
     defaultUnit: 'Nm³',
-    defaultEmissionFactorKgPerUnit: 2.05
+    defaultEmissionFactorKgPerUnit: 2.05,
+    energyContentMjPerUnit: 39.8
   },
   diesel: {
     label: 'Diesel',
     defaultUnit: 'liter',
-    defaultEmissionFactorKgPerUnit: 2.68
+    defaultEmissionFactorKgPerUnit: 2.68,
+    energyContentMjPerUnit: 36.0
   },
   fyringsolie: {
     label: 'Fyringsolie',
     defaultUnit: 'liter',
-    defaultEmissionFactorKgPerUnit: 2.96
+    defaultEmissionFactorKgPerUnit: 2.96,
+    energyContentMjPerUnit: 38.2
   },
   biogas: {
     label: 'Biogas',
     defaultUnit: 'Nm³',
-    defaultEmissionFactorKgPerUnit: 0.1
+    defaultEmissionFactorKgPerUnit: 0.1,
+    energyContentMjPerUnit: 21.0
+  },
+  lpg: {
+    label: 'LPG',
+    defaultUnit: 'liter',
+    defaultEmissionFactorKgPerUnit: 3.0,
+    energyContentMjPerUnit: 26.0
   }
 } as const
 
@@ -53,7 +63,8 @@ export const a1FuelOptions = (Object.entries(a1FuelConfigurations) as Array<
   value,
   label: config.label,
   unit: config.defaultUnit,
-  defaultEmissionFactorKgPerUnit: config.defaultEmissionFactorKgPerUnit
+  defaultEmissionFactorKgPerUnit: config.defaultEmissionFactorKgPerUnit,
+  energyContentMjPerUnit: config.energyContentMjPerUnit
 }))
 
 export function runA1(input: ModuleInput): ModuleResult {

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -10,7 +10,7 @@ const d1DataQualityOptions = ['primary', 'secondary', 'proxy'] as const
 
 const a1FuelConsumptionSchema = z
   .object({
-    fuelType: z.enum(['naturgas', 'diesel', 'fyringsolie', 'biogas']),
+    fuelType: z.enum(['naturgas', 'diesel', 'fyringsolie', 'biogas', 'lpg']),
     unit: z.enum(['liter', 'Nm³', 'kg']),
     quantity: z.number().min(0).nullable(),
     emissionFactorKgPerUnit: z.number().min(0).nullable(),


### PR DESCRIPTION
## Summary
- create a configurable wizard step builder to render number, select, percent, and file fields across modules
- update scope 1 modules (A1–A4) with energy content display, emission factor sources, documentation uploads, and LPG support in shared config
- refactor scope 2 modules (B1–B11) to use the builder with dropdown emission factors, documentation quality scoring, and file attachments

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de43c6f24083258ab22a08c0111ccd