### PR TITLE
feat: add pre-wizard company profile questionnaire

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -57,3 +57,32 @@ Fejltyper vi kender
 • NPM-auth: brug env-variabel i CI. Ingen .env indlæsning i npm.
 • Merge-konflikter: GitHub accepterer ikke filer med `<<<<<<<`/`=======`/`>>>>>>>`. Ryd altid markørerne og bekræft med `rg '<<<<<<<'` før commit.
 
+## 2024-UI-v4 opdatering
+
+### Ændrede filer og formål
+• `apps/web/styles/design-system.css`: fælles designsystem med spacing-, farve- og komponentklasser brugt på tværs af appen.
+• `apps/web/app/layout.tsx`, `apps/web/app/page.tsx`, `apps/web/features/wizard/WizardShell.tsx`: opdateret layout til at bruge designsystemet samt forbedret navigation/landing.
+• `apps/web/components/ui/PrimaryButton.tsx`: knappen er nu klasse-baseret med ghost-variant, så knapper deler styling.
+• `apps/web/features/wizard/steps/B1.tsx` – `B6.tsx`: scope 2-formularer har inline-hjælp, validering, designsystem-klassser og opdaterede summaries.
+• `apps/web/features/wizard/useWizard.ts`: autosave er debounced og persistensen sikres ved `beforeunload`.
+• `apps/web/app/(review)/review/page.tsx` og `apps/web/features/pdf/ReportPreviewClient.tsx`: review-siden viser sekundære moduler, bruger designsystemet og indlejrer PDF-preview.
+• `apps/web/src/modules/wizard/*.tsx`: virksomhedsprofilen styrer hvilke moduler der er aktive i wizard-navigationen.
+
+### Sådan fortsætter du arbejdet
+• Genbrug `ds-*`-klasserne og PrimaryButton-varianten i nye UI-komponenter for konsistens.
+• Når andre modultrin skal redesignes, brug B1–B6 som reference for valideringsmønster og hjælpetekster.
+• Overvej at udvide designsystemet med flere util-klasser i `design-system.css` frem for at bruge inline-styles.
+• Hvis yderligere validering skal tilføjes, kan `TouchedMap`-mønstret fra B1–B6 genbruges og udvides til komplekse trin.
+
+### Tests og builds
+• Kør `pnpm --filter @org/web build` for at validere lint, typer og Next build.
+• Kør `pnpm --filter @org/web test` for at køre UI- og komponenttests.
+
+### Virksomhedsprofil (PreWizardQuestionnaire)
+• Fil: `apps/web/src/modules/wizard/PreWizardQuestionnaire.tsx`  
+• Formål: Identificere relevante ESG-moduler via ja/nej-spørgsmål  
+• Output: `wizardProfile` (lagret i localStorage)  
+• Bruges i: `WizardOverview.tsx` (filtrering af moduler)  
+• Design: Bruger eksisterende komponenter fra `@org/shared` og `design-system.css`  
+• Test: `pnpm --filter @org/web build && pnpm --filter @org/web test`
+

--- a/apps/web/app/(review)/review/page.tsx
+++ b/apps/web/app/(review)/review/page.tsx
@@ -4,22 +4,14 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, type CSSProperties } from 'react'
+import { useMemo } from 'react'
 
 import { PrimaryButton } from '../../../components/ui/PrimaryButton'
 import { downloadReport } from '../../../features/pdf/downloadClient'
+import ReportPreviewClient from '../../../features/pdf/ReportPreviewClient'
 import { useLiveResults } from '../../../features/results/useLiveResults'
 
 import type { CalculatedModuleResult } from '@org/shared'
-
-const cardStyle: CSSProperties = {
-  padding: '1.5rem',
-  borderRadius: '0.75rem',
-  border: '1px solid #d0d7d5',
-  background: '#fff',
-  display: 'grid',
-  gap: '0.75rem'
-}
 
 export default function ReviewPage(): JSX.Element {
   const { results } = useLiveResults()
@@ -43,48 +35,71 @@ export default function ReviewPage(): JSX.Element {
   }
 
   return (
-    <main style={{ padding: '2rem', display: 'grid', gap: '2rem', alignContent: 'start' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h1>Review og download</h1>
-        <p style={{ maxWidth: '48rem' }}>
-          Et overblik over beregnede Scope 1-, Scope 3- og governance-resultater. D1-modulet leverer en samlet score for metode
-          og governance og følger med i PDF-downloaden.
+    <main className="ds-page ds-stack">
+      <header className="ds-stack-sm">
+        <p className="ds-text-subtle">Version 4 · Resultatoversigt og rapport</p>
+        <h1 className="ds-heading-lg">Review og download</h1>
+        <p className="ds-text-muted">
+          Få et samlet overblik over beregnede Scope 1-, Scope 3- og governance-resultater. D1-modulet leverer en samlet score,
+          som indgår direkte i PDF-rapporten.
         </p>
       </header>
 
       {primaryResults.length > 0 ? (
-        <section style={{ display: 'grid', gap: '1.5rem' }}>
-          {primaryResults.map((entry) => (
-            <ResultCard key={entry.moduleId} entry={entry} />
-          ))}
+        <section className="ds-stack">
+          <h2 className="ds-section-heading">Primære Scope 2-moduler</h2>
+          <div className="ds-stack">
+            {primaryResults.map((entry) => (
+              <ResultCard key={entry.moduleId} entry={entry} />
+            ))}
+          </div>
         </section>
       ) : (
         <EmptyCard />
       )}
 
       {secondaryResults.length > 0 && (
-        <section style={{ display: 'grid', gap: '1rem' }}>
-          <h2>Andre moduler</h2>
-          <p style={{ margin: 0, color: '#555' }}>
-            De øvrige moduler inkluderer både Scope 3-kategorier og governance-scoren fra D1 – Metode &amp; governance.
-          </p>
+        <section className="ds-stack">
+          <div className="ds-stack-sm">
+            <h2 className="ds-section-heading">Andre moduler</h2>
+            <p className="ds-text-subtle">
+              Omfatter Scope 1-, Scope 3- og governance-resultater, som supplerer Scope 2-beregningerne.
+            </p>
+          </div>
+          <div className="ds-stack">
+            {secondaryResults.map((entry) => (
+              <ResultCard key={entry.moduleId} entry={entry} />
+            ))}
+          </div>
         </section>
       )}
 
-      <section style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      {printable.length > 0 && (
+        <section className="ds-stack">
+          <div className="ds-stack-sm">
+            <h2 className="ds-section-heading">PDF-preview</h2>
+            <p className="ds-text-subtle">
+              Forhåndsvis rapporten direkte i browseren. Download-knappen genererer den samme rapport lokalt.
+            </p>
+          </div>
+          <div className="ds-scroll-panel" data-size="tall">
+            <ReportPreviewClient results={printable} />
+          </div>
+        </section>
+      )}
+
+      <section className="ds-toolbar">
         <PrimaryButton onClick={handleDownload} disabled={!printable.length}>
           Download PDF
         </PrimaryButton>
-        <PrimaryButton as={Link} href="/wizard">
+        <PrimaryButton as={Link} href="/wizard" variant="ghost">
           Tilbage til wizard
         </PrimaryButton>
       </section>
 
-      <details>
+      <details className="ds-card">
         <summary>Se rå data</summary>
-        <pre style={{ background: '#f8faf9', padding: '1rem', borderRadius: '0.5rem' }}>
-          {JSON.stringify(printable, null, 2)}
-        </pre>
+        <pre className="ds-summary ds-code">{JSON.stringify(printable, null, 2)}</pre>
       </details>
     </main>
   )
@@ -93,14 +108,14 @@ export default function ReviewPage(): JSX.Element {
 function ResultCard({ entry }: { entry: CalculatedModuleResult }): JSX.Element {
   const { result } = entry
   return (
-    <section style={cardStyle}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2 style={{ margin: 0 }}>{entry.title}</h2>
-        <p style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600 }}>
+    <section className="ds-card">
+      <header className="ds-stack-sm">
+        <h3 className="ds-heading-sm">{entry.title}</h3>
+        <p className="ds-value">
           {result.value} {result.unit}
         </p>
       </header>
-      <div>
+      <div className="ds-stack-sm">
         <strong>Antagelser</strong>
         <ul>
           {result.assumptions.map((assumption, index) => (
@@ -109,7 +124,7 @@ function ResultCard({ entry }: { entry: CalculatedModuleResult }): JSX.Element {
         </ul>
       </div>
       {result.warnings.length > 0 && (
-        <div>
+        <div className="ds-stack-sm">
           <strong>Advarsler</strong>
           <ul>
             {result.warnings.map((warning, index) => (
@@ -118,11 +133,11 @@ function ResultCard({ entry }: { entry: CalculatedModuleResult }): JSX.Element {
           </ul>
         </div>
       )}
-      <details>
+      <details className="ds-summary">
         <summary>Trace</summary>
         <ul>
           {result.trace.map((traceEntry, index) => (
-            <li key={`${entry.moduleId}-trace-${index}`} style={{ fontFamily: 'monospace' }}>
+            <li key={`${entry.moduleId}-trace-${index}`} className="ds-code">
               {traceEntry}
             </li>
           ))}
@@ -134,12 +149,11 @@ function ResultCard({ entry }: { entry: CalculatedModuleResult }): JSX.Element {
 
 function EmptyCard(): JSX.Element {
   return (
-    <section style={{ ...cardStyle, background: '#f8faf9', borderStyle: 'dashed' }}>
-      <h2 style={{ margin: 0 }}>Ingen data endnu</h2>
-      <p style={{ margin: 0 }}>
-        Når du udfylder de beregningsklare Scope 1- og Scope 3-moduler vises resultaterne her. Governance-modulet D1 beregner en
-        samlet score for metode, screening og politikker.
-
+    <section className="ds-card ds-card--muted">
+      <h2 className="ds-heading-sm">Ingen data endnu</h2>
+      <p>
+        Når du udfylder de beregningsklare moduler vises resultaterne her. Governance-modulet D1 beregner en samlet score for
+        metode, screening og politikker.
       </p>
     </section>
   )

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@
  */
 import type { Metadata } from 'next'
 import './globals.css'
+import '../styles/design-system.css'
 
 export const metadata: Metadata = {
   title: 'ESG-rapportering',

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,12 +7,13 @@ import { PrimaryButton } from '../components/ui/PrimaryButton'
 
 export default function HomePage(): JSX.Element {
   return (
-    <main style={{ display: 'grid', placeItems: 'center', minHeight: '100vh' }}>
-      <section style={{ textAlign: 'center' }}>
-        <h1>ESG-rapportering</h1>
-        <p>
+    <main className="ds-hero">
+      <section className="ds-stack-sm ds-constrain">
+        <p className="ds-text-subtle">Version 4 · Ny UI-oplevelse</p>
+        <h1 className="ds-heading-lg">ESG-rapportering</h1>
+        <p className="ds-text-muted">
           Start beregning for at udfylde Scope 1- og Scope 2-modulerne, Scope 3-udvidelserne og governance-scoren for D1 –
-          Metode &amp; governance.
+          Metode &amp; governance. Alle indtastninger kan redigeres senere i wizard-flowet.
         </p>
         <PrimaryButton as={Link} href="/wizard">
           Start beregning

--- a/apps/web/components/ui/PrimaryButton.tsx
+++ b/apps/web/components/ui/PrimaryButton.tsx
@@ -1,32 +1,26 @@
 /**
  * Simpel primærknap der kan rendere som link eller button.
  */
-import type { ComponentProps, CSSProperties, ElementType, ReactNode } from 'react'
+import type { ComponentProps, ElementType, ReactNode } from 'react'
+
+type PrimaryVariant = 'primary' | 'ghost'
 
 type PolymorphicProps<T extends ElementType> = {
   as?: T
   children: ReactNode
-  style?: CSSProperties
+  className?: string
+  variant?: PrimaryVariant
 } & Omit<ComponentProps<T>, 'as' | 'children' | 'style'>
 
 export function PrimaryButton<T extends ElementType = 'button'>(
-  { as, children, style, ...rest }: PolymorphicProps<T>
+  { as, children, className, variant = 'primary', ...rest }: PolymorphicProps<T>
 ): JSX.Element {
   const Component = (as ?? 'button') as ElementType
-  const baseStyle: CSSProperties = {
-    padding: '0.75rem 1.5rem',
-    backgroundColor: '#0a7d55',
-    color: '#fff',
-    borderRadius: '0.5rem',
-    textDecoration: 'none',
-    border: 'none',
-    display: 'inline-block',
-    cursor: 'pointer'
-  }
 
   const componentProps = {
     ...rest,
-    style: { ...baseStyle, ...(style ?? {}) }
+    className: ['ds-button', className].filter(Boolean).join(' '),
+    'data-variant': variant === 'ghost' ? 'ghost' : undefined
   } as ComponentProps<T>
 
   if (Component === 'button' && !(componentProps as ComponentProps<'button'>).type) {

--- a/apps/web/features/pdf/ReportPreviewClient.tsx
+++ b/apps/web/features/pdf/ReportPreviewClient.tsx
@@ -29,7 +29,7 @@ export default function ReportPreviewClient({
   }
 
   return (
-    <PDFViewer style={{ width: '100%', height: '80vh' }}>
+    <PDFViewer style={{ width: '100%', height: '100%' }}>
       <DocumentComponent results={printable} />
     </PDFViewer>
   )

--- a/apps/web/features/wizard/WizardShell.tsx
+++ b/apps/web/features/wizard/WizardShell.tsx
@@ -3,62 +3,114 @@
  */
 'use client'
 
-import { wizardSteps, type WizardScope } from './steps'
-import { useWizard } from './useWizard'
+import { useEffect, useMemo, useState } from 'react'
+
 import { PrimaryButton } from '../../components/ui/PrimaryButton'
+import { PreWizardQuestionnaire } from '../../src/modules/wizard/PreWizardQuestionnaire'
+import { WizardOverview } from '../../src/modules/wizard/WizardOverview'
+import {
+  findFirstRelevantStepIndex,
+  hasAnyAnswer,
+  isModuleRelevant,
+} from '../../src/modules/wizard/profile'
+import { wizardSteps } from './steps'
+import { useWizard } from './useWizard'
 
 export function WizardShell(): JSX.Element {
-  const { currentStep, goToStep, state, updateField } = useWizard()
+  const { currentStep, goToStep, state, updateField, profile, updateProfile } = useWizard()
+  const [isProfileOpen, setIsProfileOpen] = useState(() => !hasAnyAnswer(profile))
   const StepComponent = wizardSteps[currentStep]?.component
-  const stepIndexById = new Map(wizardSteps.map((step, index) => [step.id, index]))
+  const firstRelevantStepIndex = useMemo(
+    () => findFirstRelevantStepIndex(wizardSteps, profile),
+    [profile]
+  )
 
-  const scopeOrder: WizardScope[] = ['Scope 1', 'Scope 2', 'Scope 3', 'Governance']
-  const stepsByScope = scopeOrder
-    .map((scope) => ({ scope, steps: wizardSteps.filter((step) => step.scope === scope) }))
-    .filter((entry) => entry.steps.length > 0)
+  useEffect(() => {
+    if (!hasAnyAnswer(profile)) {
+      setIsProfileOpen(true)
+    }
+  }, [profile])
+
+  useEffect(() => {
+    if (isProfileOpen) {
+      return
+    }
+    const current = wizardSteps[currentStep]
+    if (!current) {
+      return
+    }
+    if (!isModuleRelevant(profile, current.id) && currentStep !== firstRelevantStepIndex) {
+      goToStep(firstRelevantStepIndex)
+    }
+  }, [currentStep, firstRelevantStepIndex, goToStep, isProfileOpen, profile])
+
+  const handleOpenProfile = () => {
+    setIsProfileOpen(true)
+  }
+
+  const handleCompleteProfile = () => {
+    setIsProfileOpen(false)
+    goToStep(firstRelevantStepIndex)
+  }
 
   return (
-    <section style={{ padding: '2rem' }}>
-      <h1>ESG Wizard</h1>
-      <nav style={{ display: 'grid', gap: '1.5rem' }}>
-        {stepsByScope.map(({ scope, steps }) => (
-          <section key={scope} style={{ display: 'grid', gap: '0.75rem' }}>
-            <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{scope}</h2>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-              {steps.map((step) => {
-                const index = stepIndexById.get(step.id) ?? 0
-                const isActive = index === currentStep
-                const isPlanned = step.status === 'planned'
-                return (
-                  <PrimaryButton
-                    key={step.id}
-                    onClick={() => goToStep(index)}
-                    aria-pressed={isActive}
-                    title={isPlanned ? 'Planlagt modul – beregningslogik følger.' : undefined}
-                    style={{
-                      backgroundColor: isActive ? '#0a7d55' : '#0a7d55',
-                      opacity: isPlanned && !isActive ? 0.75 : 1,
-                      border: isActive ? '2px solid #064f37' : 'none'
-                    }}
-                  >
-                    <span style={{ display: 'block' }}>{step.label}</span>
-                    {isPlanned && (
-                      <span style={{ display: 'block', fontSize: '0.75rem', opacity: 0.85 }}>Planlagt</span>
-                    )}
-                  </PrimaryButton>
-                )
-              })}
-            </div>
-          </section>
-        ))}
-      </nav>
-      <div style={{ marginTop: '2rem' }}>
-        {StepComponent ? (
-          <StepComponent state={state} onChange={updateField} />
-        ) : (
-          <p>Ingen trin fundet.</p>
-        )}
-      </div>
+    <section className="ds-page ds-stack">
+      <header className="ds-stack">
+        <div className="ds-question-card__header">
+          <div className="ds-stack-sm">
+            <p className="ds-text-subtle">Version 4 · Opdateret wizard-oplevelse</p>
+            <h1 className="ds-heading-lg">ESG-beregninger</h1>
+            <p className="ds-text-muted">
+              Navigér mellem modulerne for Scope 1, Scope 3 og governance. Dine indtastninger bliver gemt løbende, og hvert
+              modul viser relevante hjælpetekster og validering.
+            </p>
+          </div>
+          <PrimaryButton variant="ghost" onClick={handleOpenProfile} disabled={isProfileOpen}>
+            Rediger profil
+          </PrimaryButton>
+        </div>
+      </header>
+
+      {isProfileOpen ? (
+        <PreWizardQuestionnaire
+          profile={profile}
+          onChange={updateProfile}
+          onContinue={handleCompleteProfile}
+        />
+      ) : (
+        <>
+          <WizardOverview
+            steps={wizardSteps}
+            currentStep={currentStep}
+            onSelect={goToStep}
+            profile={profile}
+          />
+
+          <div>
+            {StepComponent ? (
+              <StepComponent state={state} onChange={updateField} />
+            ) : (
+              <p className="ds-text-muted">Ingen trin fundet.</p>
+            )}
+          </div>
+
+          <footer className="ds-toolbar">
+            <PrimaryButton
+              onClick={() => goToStep(Math.max(0, currentStep - 1))}
+              disabled={currentStep === 0}
+              variant="ghost"
+            >
+              Forrige trin
+            </PrimaryButton>
+            <PrimaryButton
+              onClick={() => goToStep(Math.min(wizardSteps.length - 1, currentStep + 1))}
+              disabled={currentStep === wizardSteps.length - 1}
+            >
+              Næste trin
+            </PrimaryButton>
+          </footer>
+        </>
+      )}
     </section>
   )
 }

--- a/apps/web/features/wizard/steps/B3.tsx
+++ b/apps/web/features/wizard/steps/B3.tsx
@@ -3,8 +3,8 @@
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
+import { useMemo, useState } from 'react'
+import type { ChangeEvent, FocusEvent } from 'react'
 import type { B3Input, ModuleInput, ModuleResult } from '@org/shared'
 import { runB3 } from '@org/shared'
 import type { WizardStepProps } from './StepTemplate'
@@ -17,6 +17,7 @@ type FieldConfig = {
   description: string
   unit: string
   placeholder?: string
+  required?: boolean
 }
 
 const FIELD_CONFIG: FieldConfig[] = [
@@ -24,7 +25,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     key: 'coolingConsumptionKwh',
     label: 'Årligt køleforbrug',
     description: 'Samlet køleenergi leveret fra forsyningen i kWh.',
-    unit: 'kWh'
+    unit: 'kWh',
+    required: true
   },
   {
     key: 'recoveredCoolingKwh',
@@ -37,7 +39,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     label: 'Emissionsfaktor',
     description: 'Kg CO2e pr. kWh i køleleverandørens miljødeklaration.',
     unit: 'kg CO2e/kWh',
-    placeholder: '0.030'
+    placeholder: '0.030',
+    required: true
   },
   {
     key: 'renewableSharePercent',
@@ -55,12 +58,21 @@ const EMPTY_B3: B3Input = {
   renewableSharePercent: null
 }
 
+type TouchedMap = Partial<Record<FieldKey, boolean>>
+
+type ErrorMap = Partial<Record<FieldKey, string>>
+
 export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
   const current = (state.B3 as B3Input | undefined) ?? EMPTY_B3
+  const [touched, setTouched] = useState<TouchedMap>({})
 
   const preview = useMemo<ModuleResult>(() => {
     return runB3({ B3: current } as ModuleInput)
   }, [current])
+
+  const handleFieldBlur = (field: FieldKey) => (_event: FocusEvent<HTMLInputElement>) => {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
 
   const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value.replace(',', '.')
@@ -72,6 +84,36 @@ export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
     onChange('B3', next)
   }
 
+  const errors = useMemo<ErrorMap>(() => {
+    const nextErrors: ErrorMap = {}
+
+    FIELD_CONFIG.forEach(({ key, required }) => {
+      const value = current[key]
+      if (value == null) {
+        if (required && touched[key]) {
+          nextErrors[key] = 'Feltet er påkrævet.'
+        }
+        return
+      }
+
+      if (Number.isNaN(value)) {
+        nextErrors[key] = 'Angiv et gyldigt tal.'
+        return
+      }
+
+      if (value < 0) {
+        nextErrors[key] = 'Værdien skal være positiv.'
+        return
+      }
+
+      if (key === 'renewableSharePercent' && value > 100) {
+        nextErrors[key] = 'Vedvarende andel kan højst være 100%.'
+      }
+    })
+
+    return nextErrors
+  }, [current, touched])
+
   const hasData =
     preview.trace.some((line) => line.includes('netCoolingConsumptionKwh')) &&
     (current.coolingConsumptionKwh != null ||
@@ -80,46 +122,58 @@ export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
       current.renewableSharePercent != null)
 
   return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B3 – Scope 2 køleforbrug</h2>
-        <p>
-          Indtast data for organisationens indkøbte køling. Beregningen korrigerer for frikøling/genindvinding og
-          dokumenteret vedvarende leverancer.
+    <form className="ds-form" noValidate>
+      <header className="ds-stack-sm">
+        <h2 className="ds-heading-sm">B3 – Scope 2 køleforbrug</h2>
+        <p className="ds-text-muted">
+          Indtast data for organisationens indkøbte køling. Beregningen korrigerer for frikøling, genindvinding og dokumenteret
+          vedvarende leverancer.
         </p>
+        <p className="ds-text-subtle">Kontrollér at emissionsfaktoren matcher leverandørens seneste deklaration.</p>
       </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
+
+      <section className="ds-stack">
         {FIELD_CONFIG.map((field) => {
           const value = current[field.key]
+          const error = errors[field.key]
+          const isInvalid = Boolean(error)
           return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
+            <label key={field.key} className="ds-field">
+              <span>
                 {field.label} ({field.unit})
               </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <span className="ds-field-help">{field.description}</span>
               <input
                 type="number"
                 step="any"
                 value={value ?? ''}
                 placeholder={field.placeholder}
                 onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                onBlur={handleFieldBlur(field.key)}
+                className="ds-input"
+                data-invalid={isInvalid ? 'true' : 'false'}
                 min={0}
+                aria-invalid={isInvalid}
+                aria-describedby={isInvalid ? `${field.key}-error` : undefined}
               />
+              {isInvalid && (
+                <p id={`${field.key}-error`} className="ds-error">
+                  {error}
+                </p>
+              )}
             </label>
           )
         })}
       </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
+
+      <section className="ds-summary ds-stack-sm">
+        <h3 className="ds-heading-sm">Estimat</h3>
         {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+          <div className="ds-stack-sm">
+            <p className="ds-value">
               {preview.value} {preview.unit}
             </p>
-            <div>
+            <div className="ds-stack-sm">
               <strong>Antagelser</strong>
               <ul>
                 {preview.assumptions.map((assumption, index) => (
@@ -128,7 +182,7 @@ export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
               </ul>
             </div>
             {preview.warnings.length > 0 && (
-              <div>
+              <div className="ds-stack-sm">
                 <strong>Advarsler</strong>
                 <ul>
                   {preview.warnings.map((warning, index) => (
@@ -137,11 +191,11 @@ export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
                 </ul>
               </div>
             )}
-            <details>
+            <details className="ds-summary">
               <summary>Teknisk trace</summary>
               <ul>
                 {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                  <li key={index} className="ds-code">
                     {line}
                   </li>
                 ))}
@@ -149,7 +203,7 @@ export function B3Step({ state, onChange }: WizardStepProps): JSX.Element {
             </details>
           </div>
         ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
+          <p className="ds-text-muted">Udfyld felterne for at se beregnet nettoemission.</p>
         )}
       </section>
     </form>

--- a/apps/web/features/wizard/steps/B4.tsx
+++ b/apps/web/features/wizard/steps/B4.tsx
@@ -3,8 +3,8 @@
  */
 'use client'
 
-import { useMemo } from 'react'
-import type { ChangeEvent } from 'react'
+import { useMemo, useState } from 'react'
+import type { ChangeEvent, FocusEvent } from 'react'
 import type { B4Input, ModuleInput, ModuleResult } from '@org/shared'
 import { runB4 } from '@org/shared'
 import type { WizardStepProps } from './StepTemplate'
@@ -17,6 +17,7 @@ type FieldConfig = {
   description: string
   unit: string
   placeholder?: string
+  required?: boolean
 }
 
 const FIELD_CONFIG: FieldConfig[] = [
@@ -24,7 +25,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     key: 'steamConsumptionKwh',
     label: 'Årligt dampforbrug',
     description: 'Samlet dampenergi leveret fra forsyningen i kWh.',
-    unit: 'kWh'
+    unit: 'kWh',
+    required: true
   },
   {
     key: 'recoveredSteamKwh',
@@ -37,7 +39,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     label: 'Emissionsfaktor',
     description: 'Kg CO2e pr. kWh i dampforsyningens miljødeklaration.',
     unit: 'kg CO2e/kWh',
-    placeholder: '0.090'
+    placeholder: '0.090',
+    required: true
   },
   {
     key: 'renewableSharePercent',
@@ -55,12 +58,21 @@ const EMPTY_B4: B4Input = {
   renewableSharePercent: null
 }
 
+type TouchedMap = Partial<Record<FieldKey, boolean>>
+
+type ErrorMap = Partial<Record<FieldKey, string>>
+
 export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
-  const current = (state['B4'] as B4Input | undefined) ?? EMPTY_B4
+  const current = (state.B4 as B4Input | undefined) ?? EMPTY_B4
+  const [touched, setTouched] = useState<TouchedMap>({})
 
   const preview = useMemo<ModuleResult>(() => {
     return runB4({ B4: current } as ModuleInput)
   }, [current])
+
+  const handleFieldBlur = (field: FieldKey) => (_event: FocusEvent<HTMLInputElement>) => {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
 
   const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value.replace(',', '.')
@@ -72,6 +84,36 @@ export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
     onChange('B4', next)
   }
 
+  const errors = useMemo<ErrorMap>(() => {
+    const nextErrors: ErrorMap = {}
+
+    FIELD_CONFIG.forEach(({ key, required }) => {
+      const value = current[key]
+      if (value == null) {
+        if (required && touched[key]) {
+          nextErrors[key] = 'Feltet er påkrævet.'
+        }
+        return
+      }
+
+      if (Number.isNaN(value)) {
+        nextErrors[key] = 'Angiv et gyldigt tal.'
+        return
+      }
+
+      if (value < 0) {
+        nextErrors[key] = 'Værdien skal være positiv.'
+        return
+      }
+
+      if (key === 'renewableSharePercent' && value > 100) {
+        nextErrors[key] = 'Vedvarende andel kan højst være 100%.'
+      }
+    })
+
+    return nextErrors
+  }, [current, touched])
+
   const hasData =
     preview.trace.some((line) => line.includes('netSteamConsumptionKwh')) &&
     (current.steamConsumptionKwh != null ||
@@ -80,46 +122,58 @@ export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
       current.renewableSharePercent != null)
 
   return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B4 – Scope 2 dampforbrug</h2>
-        <p>
-          Indtast data for organisationens indkøbte damp. Beregningen korrigerer for genanvendt damp og
-          dokumenteret vedvarende leverancer.
+    <form className="ds-form" noValidate>
+      <header className="ds-stack-sm">
+        <h2 className="ds-heading-sm">B4 – Scope 2 dampforbrug</h2>
+        <p className="ds-text-muted">
+          Indtast data for organisationens indkøbte damp. Beregningen korrigerer for genanvendt damp og dokumenteret vedvarende
+          leverancer.
         </p>
+        <p className="ds-text-subtle">Brug kWh-enheder for sammenlignelighed med andre energityper.</p>
       </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
+
+      <section className="ds-stack">
         {FIELD_CONFIG.map((field) => {
           const value = current[field.key]
+          const error = errors[field.key]
+          const isInvalid = Boolean(error)
           return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
+            <label key={field.key} className="ds-field">
+              <span>
                 {field.label} ({field.unit})
               </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <span className="ds-field-help">{field.description}</span>
               <input
                 type="number"
                 step="any"
                 value={value ?? ''}
                 placeholder={field.placeholder}
                 onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                onBlur={handleFieldBlur(field.key)}
+                className="ds-input"
+                data-invalid={isInvalid ? 'true' : 'false'}
                 min={0}
+                aria-invalid={isInvalid}
+                aria-describedby={isInvalid ? `${field.key}-error` : undefined}
               />
+              {isInvalid && (
+                <p id={`${field.key}-error`} className="ds-error">
+                  {error}
+                </p>
+              )}
             </label>
           )
         })}
       </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
+
+      <section className="ds-summary ds-stack-sm">
+        <h3 className="ds-heading-sm">Estimat</h3>
         {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+          <div className="ds-stack-sm">
+            <p className="ds-value">
               {preview.value} {preview.unit}
             </p>
-            <div>
+            <div className="ds-stack-sm">
               <strong>Antagelser</strong>
               <ul>
                 {preview.assumptions.map((assumption, index) => (
@@ -128,7 +182,7 @@ export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
               </ul>
             </div>
             {preview.warnings.length > 0 && (
-              <div>
+              <div className="ds-stack-sm">
                 <strong>Advarsler</strong>
                 <ul>
                   {preview.warnings.map((warning, index) => (
@@ -137,11 +191,11 @@ export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
                 </ul>
               </div>
             )}
-            <details>
+            <details className="ds-summary">
               <summary>Teknisk trace</summary>
               <ul>
                 {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                  <li key={index} className="ds-code">
                     {line}
                   </li>
                 ))}
@@ -149,7 +203,7 @@ export function B4Step({ state, onChange }: WizardStepProps): JSX.Element {
             </details>
           </div>
         ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
+          <p className="ds-text-muted">Udfyld felterne for at se beregnet nettoemission.</p>
         )}
       </section>
     </form>

--- a/apps/web/features/wizard/steps/B5.tsx
+++ b/apps/web/features/wizard/steps/B5.tsx
@@ -3,11 +3,10 @@
  */
 'use client'
 
-import { useMemo, type ChangeEvent } from 'react'
-
+import { useMemo, useState } from 'react'
+import type { ChangeEvent, FocusEvent } from 'react'
 import type { B5Input, ModuleInput, ModuleResult } from '@org/shared'
 import { runB5 } from '@org/shared'
-
 import type { WizardStepProps } from './StepTemplate'
 
 type FieldKey = keyof B5Input
@@ -18,6 +17,7 @@ type FieldConfig = {
   description: string
   unit: string
   placeholder?: string
+  required?: boolean
 }
 
 const FIELD_CONFIG: FieldConfig[] = [
@@ -25,7 +25,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     key: 'otherEnergyConsumptionKwh',
     label: 'Årligt forbrug',
     description: 'Samlet mængde indkøbt energi for den valgte leverance i kWh.',
-    unit: 'kWh'
+    unit: 'kWh',
+    required: true
   },
   {
     key: 'recoveredEnergyKwh',
@@ -38,7 +39,8 @@ const FIELD_CONFIG: FieldConfig[] = [
     label: 'Emissionsfaktor',
     description: 'Kg CO2e pr. kWh ifølge leverandørens miljødeklaration.',
     unit: 'kg CO2e/kWh',
-    placeholder: '0.075'
+    placeholder: '0.075',
+    required: true
   },
   {
     key: 'renewableSharePercent',
@@ -56,12 +58,21 @@ const EMPTY_B5: B5Input = {
   renewableSharePercent: null
 }
 
+type TouchedMap = Partial<Record<FieldKey, boolean>>
+
+type ErrorMap = Partial<Record<FieldKey, string>>
+
 export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
   const current = (state.B5 as B5Input | undefined) ?? EMPTY_B5
+  const [touched, setTouched] = useState<TouchedMap>({})
 
   const preview = useMemo<ModuleResult>(() => {
     return runB5({ B5: current } as ModuleInput)
   }, [current])
+
+  const handleFieldBlur = (field: FieldKey) => (_event: FocusEvent<HTMLInputElement>) => {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
 
   const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value.replace(',', '.')
@@ -73,6 +84,36 @@ export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
     onChange('B5', next)
   }
 
+  const errors = useMemo<ErrorMap>(() => {
+    const nextErrors: ErrorMap = {}
+
+    FIELD_CONFIG.forEach(({ key, required }) => {
+      const value = current[key]
+      if (value == null) {
+        if (required && touched[key]) {
+          nextErrors[key] = 'Feltet er påkrævet.'
+        }
+        return
+      }
+
+      if (Number.isNaN(value)) {
+        nextErrors[key] = 'Angiv et gyldigt tal.'
+        return
+      }
+
+      if (value < 0) {
+        nextErrors[key] = 'Værdien skal være positiv.'
+        return
+      }
+
+      if (key === 'renewableSharePercent' && value > 100) {
+        nextErrors[key] = 'Vedvarende andel kan højst være 100%.'
+      }
+    })
+
+    return nextErrors
+  }, [current, touched])
+
   const hasData =
     preview.trace.some((line) => line.includes('netOtherEnergyConsumptionKwh')) &&
     (current.otherEnergyConsumptionKwh != null ||
@@ -81,46 +122,58 @@ export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
       current.renewableSharePercent != null)
 
   return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B5 – Scope 2 øvrige energileverancer</h2>
-        <p>
-          Indtast data for energileverancer som ikke dækkes af el, varme, køling eller damp. Beregningen korrigerer for
+    <form className="ds-form" noValidate>
+      <header className="ds-stack-sm">
+        <h2 className="ds-heading-sm">B5 – Scope 2 øvrige energileverancer</h2>
+        <p className="ds-text-muted">
+          Indtast data for energileverancer, som ikke dækkes af el, varme, køling eller damp. Beregningen korrigerer for
           genindvundet energi og dokumenteret vedvarende andel.
         </p>
+        <p className="ds-text-subtle">Benyt kWh som standardenhed for at sammenligne på tværs af energityper.</p>
       </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
+
+      <section className="ds-stack">
         {FIELD_CONFIG.map((field) => {
           const value = current[field.key]
+          const error = errors[field.key]
+          const isInvalid = Boolean(error)
           return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
+            <label key={field.key} className="ds-field">
+              <span>
                 {field.label} ({field.unit})
               </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <span className="ds-field-help">{field.description}</span>
               <input
                 type="number"
                 step="any"
                 value={value ?? ''}
                 placeholder={field.placeholder}
                 onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                onBlur={handleFieldBlur(field.key)}
+                className="ds-input"
+                data-invalid={isInvalid ? 'true' : 'false'}
                 min={0}
+                aria-invalid={isInvalid}
+                aria-describedby={isInvalid ? `${field.key}-error` : undefined}
               />
+              {isInvalid && (
+                <p id={`${field.key}-error`} className="ds-error">
+                  {error}
+                </p>
+              )}
             </label>
           )
         })}
       </section>
-      <section
-        style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}
-      >
-        <h3 style={{ margin: 0 }}>Estimat</h3>
+
+      <section className="ds-summary ds-stack-sm">
+        <h3 className="ds-heading-sm">Estimat</h3>
         {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+          <div className="ds-stack-sm">
+            <p className="ds-value">
               {preview.value} {preview.unit}
             </p>
-            <div>
+            <div className="ds-stack-sm">
               <strong>Antagelser</strong>
               <ul>
                 {preview.assumptions.map((assumption, index) => (
@@ -129,7 +182,7 @@ export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
               </ul>
             </div>
             {preview.warnings.length > 0 && (
-              <div>
+              <div className="ds-stack-sm">
                 <strong>Advarsler</strong>
                 <ul>
                   {preview.warnings.map((warning, index) => (
@@ -138,11 +191,11 @@ export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
                 </ul>
               </div>
             )}
-            <details>
+            <details className="ds-summary">
               <summary>Teknisk trace</summary>
               <ul>
                 {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                  <li key={index} className="ds-code">
                     {line}
                   </li>
                 ))}
@@ -150,7 +203,7 @@ export function B5Step({ state, onChange }: WizardStepProps): JSX.Element {
             </details>
           </div>
         ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet nettoemission.</p>
+          <p className="ds-text-muted">Udfyld felterne for at se beregnet nettoemission.</p>
         )}
       </section>
     </form>

--- a/apps/web/features/wizard/steps/B6.tsx
+++ b/apps/web/features/wizard/steps/B6.tsx
@@ -3,11 +3,10 @@
  */
 'use client'
 
-import { useMemo, type ChangeEvent } from 'react'
-
+import { useMemo, useState } from 'react'
+import type { ChangeEvent, FocusEvent } from 'react'
 import type { B6Input, ModuleInput, ModuleResult } from '@org/shared'
 import { runB6 } from '@org/shared'
-
 import type { WizardStepProps } from './StepTemplate'
 
 type FieldKey = keyof B6Input
@@ -18,6 +17,7 @@ type FieldConfig = {
   description: string
   unit: string
   placeholder?: string
+  required?: boolean
 }
 
 const FIELD_CONFIG: FieldConfig[] = [
@@ -25,26 +25,29 @@ const FIELD_CONFIG: FieldConfig[] = [
     key: 'electricitySuppliedKwh',
     label: 'Årligt elforbrug (basis)',
     description: 'Den leverede mængde elektricitet som nettabbet beregnes ud fra (kWh).',
-    unit: 'kWh'
+    unit: 'kWh',
+    required: true
   },
   {
     key: 'gridLossPercent',
     label: 'Nettab',
     description: 'Forventet transmissions- og distributionstab angivet i procent af forbruget.',
     unit: '%',
-    placeholder: '0-20'
+    placeholder: '0-20',
+    required: true
   },
   {
     key: 'emissionFactorKgPerKwh',
     label: 'Emissionsfaktor',
     description: 'Kg CO2e pr. tabt kWh elektricitet. Typisk samme faktor som for elforbrug.',
     unit: 'kg CO2e/kWh',
-    placeholder: '0.233'
+    placeholder: '0.233',
+    required: true
   },
   {
     key: 'renewableSharePercent',
     label: 'Vedvarende dækning',
-    description: 'Andel af tabet der dokumenteres dækket af vedvarende energi gennem garantier eller certifikater.',
+    description: 'Andel af tabet der dokumenteres dækket af vedvarende energi.',
     unit: '%',
     placeholder: '0-100'
   }
@@ -57,12 +60,21 @@ const EMPTY_B6: B6Input = {
   renewableSharePercent: null
 }
 
+type TouchedMap = Partial<Record<FieldKey, boolean>>
+
+type ErrorMap = Partial<Record<FieldKey, string>>
+
 export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
   const current = (state.B6 as B6Input | undefined) ?? EMPTY_B6
+  const [touched, setTouched] = useState<TouchedMap>({})
 
   const preview = useMemo<ModuleResult>(() => {
     return runB6({ B6: current } as ModuleInput)
   }, [current])
+
+  const handleFieldBlur = (field: FieldKey) => (_event: FocusEvent<HTMLInputElement>) => {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
 
   const handleFieldChange = (field: FieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value.replace(',', '.')
@@ -74,6 +86,36 @@ export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
     onChange('B6', next)
   }
 
+  const errors = useMemo<ErrorMap>(() => {
+    const nextErrors: ErrorMap = {}
+
+    FIELD_CONFIG.forEach(({ key, required, unit }) => {
+      const value = current[key]
+      if (value == null) {
+        if (required && touched[key]) {
+          nextErrors[key] = 'Feltet er påkrævet.'
+        }
+        return
+      }
+
+      if (Number.isNaN(value)) {
+        nextErrors[key] = 'Angiv et gyldigt tal.'
+        return
+      }
+
+      if (value < 0) {
+        nextErrors[key] = 'Værdien skal være positiv.'
+        return
+      }
+
+      if (unit === '%' && value > 100) {
+        nextErrors[key] = 'Procentværdier kan højst være 100%.'
+      }
+    })
+
+    return nextErrors
+  }, [current, touched])
+
   const hasData =
     preview.trace.some((line) => line.includes('lossEnergyKwh')) &&
     (current.electricitySuppliedKwh != null ||
@@ -82,45 +124,60 @@ export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
       current.renewableSharePercent != null)
 
   return (
-    <form style={{ display: 'grid', gap: '1.5rem', maxWidth: '40rem' }}>
-      <header style={{ display: 'grid', gap: '0.5rem' }}>
-        <h2>B6 – Scope 2 nettab i elnettet</h2>
-        <p>
+    <form className="ds-form" noValidate>
+      <header className="ds-stack-sm">
+        <h2 className="ds-heading-sm">B6 – Scope 2 nettab i elnettet</h2>
+        <p className="ds-text-muted">
           Indtast data for transmission- og distributionstab for elektricitet. Resultatet estimerer emissionerne fra tabet og
           reducerer for dokumenteret vedvarende dækning.
         </p>
+        <p className="ds-text-subtle">Typiske nettab ligger mellem 3-8 %. Brug leverandørens faktiske tal, hvis de er tilgængelige.</p>
       </header>
-      <section style={{ display: 'grid', gap: '1rem' }}>
+
+      <section className="ds-stack">
         {FIELD_CONFIG.map((field) => {
           const value = current[field.key]
+          const error = errors[field.key]
+          const isInvalid = Boolean(error)
+          const max = field.unit === '%' ? 100 : undefined
           return (
-            <label key={field.key} style={{ display: 'grid', gap: '0.5rem' }}>
-              <span style={{ fontWeight: 600 }}>
+            <label key={field.key} className="ds-field">
+              <span>
                 {field.label} ({field.unit})
               </span>
-              <span style={{ color: '#555', fontSize: '0.9rem' }}>{field.description}</span>
+              <span className="ds-field-help">{field.description}</span>
               <input
                 type="number"
                 step="any"
                 value={value ?? ''}
                 placeholder={field.placeholder}
                 onChange={handleFieldChange(field.key)}
-                style={{ padding: '0.5rem', borderRadius: '0.375rem', border: '1px solid #ccc' }}
+                onBlur={handleFieldBlur(field.key)}
+                className="ds-input"
+                data-invalid={isInvalid ? 'true' : 'false'}
                 min={0}
-                max={field.unit === '%' ? 100 : undefined}
+                max={max}
+                aria-invalid={isInvalid}
+                aria-describedby={isInvalid ? `${field.key}-error` : undefined}
               />
+              {isInvalid && (
+                <p id={`${field.key}-error`} className="ds-error">
+                  {error}
+                </p>
+              )}
             </label>
           )
         })}
       </section>
-      <section style={{ display: 'grid', gap: '0.75rem', background: '#f1f5f4', padding: '1rem', borderRadius: '0.75rem' }}>
-        <h3 style={{ margin: 0 }}>Estimat</h3>
+
+      <section className="ds-summary ds-stack-sm">
+        <h3 className="ds-heading-sm">Estimat</h3>
         {hasData ? (
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            <p style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>
+          <div className="ds-stack-sm">
+            <p className="ds-value">
               {preview.value} {preview.unit}
             </p>
-            <div>
+            <div className="ds-stack-sm">
               <strong>Antagelser</strong>
               <ul>
                 {preview.assumptions.map((assumption, index) => (
@@ -129,7 +186,7 @@ export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
               </ul>
             </div>
             {preview.warnings.length > 0 && (
-              <div>
+              <div className="ds-stack-sm">
                 <strong>Advarsler</strong>
                 <ul>
                   {preview.warnings.map((warning, index) => (
@@ -138,11 +195,11 @@ export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
                 </ul>
               </div>
             )}
-            <details>
+            <details className="ds-summary">
               <summary>Teknisk trace</summary>
               <ul>
                 {preview.trace.map((line, index) => (
-                  <li key={index} style={{ fontFamily: 'monospace' }}>
+                  <li key={index} className="ds-code">
                     {line}
                   </li>
                 ))}
@@ -150,7 +207,7 @@ export function B6Step({ state, onChange }: WizardStepProps): JSX.Element {
             </details>
           </div>
         ) : (
-          <p style={{ margin: 0 }}>Udfyld felterne for at se beregnet emission fra nettab.</p>
+          <p className="ds-text-muted">Udfyld felterne for at se beregnet nettoemission.</p>
         )}
       </section>
     </form>

--- a/apps/web/features/wizard/useWizard.ts
+++ b/apps/web/features/wizard/useWizard.ts
@@ -5,9 +5,16 @@
 
 
 import type { ModuleInput } from '@org/shared'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { loadWizardState, persistWizardState } from '../../lib/storage/localStorage'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  loadWizardProfile,
+  loadWizardState,
+  persistWizardProfile,
+  persistWizardState,
+} from '../../lib/storage/localStorage'
 import { wizardSteps } from './steps'
+import type { WizardProfileKey } from '../../src/modules/wizard/profile'
+import { type WizardProfile } from '../../src/modules/wizard/profile'
 
 export type WizardState = ModuleInput
 
@@ -16,22 +23,57 @@ type WizardHook = {
   state: WizardState
   goToStep: (index: number) => void
   updateField: (key: string, value: unknown) => void
+  profile: WizardProfile
+  updateProfile: (key: WizardProfileKey, value: boolean | null) => void
 }
 
-const AUTOSAVE_INTERVAL = 500
+const AUTOSAVE_DELAY = 800
 const DEFAULT_STEP_INDEX = wizardSteps.findIndex((step) => step.status === 'ready')
 const INITIAL_STEP = DEFAULT_STEP_INDEX === -1 ? 0 : DEFAULT_STEP_INDEX
 
 export function useWizard(): WizardHook {
   const [currentStep, setCurrentStep] = useState(INITIAL_STEP)
   const [state, setState] = useState<WizardState>(() => loadWizardState())
+  const [profile, setProfile] = useState<WizardProfile>(() => loadWizardProfile())
+  const stateRef = useRef(state)
+  const profileRef = useRef(profile)
 
   useEffect(() => {
-    const timer = setInterval(() => {
-      persistWizardState(state)
-    }, AUTOSAVE_INTERVAL)
-    return () => clearInterval(timer)
+    stateRef.current = state
   }, [state])
+
+  useEffect(() => {
+    profileRef.current = profile
+  }, [profile])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      persistWizardState(state)
+    }, AUTOSAVE_DELAY)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [state])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      persistWizardProfile(profile)
+    }, AUTOSAVE_DELAY)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [profile])
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      persistWizardState(stateRef.current)
+      persistWizardProfile(profileRef.current)
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [])
 
   const goToStep = useCallback((index: number) => {
     setCurrentStep(Math.max(0, Math.min(index, wizardSteps.length - 1)))
@@ -41,8 +83,12 @@ export function useWizard(): WizardHook {
     setState((prev) => ({ ...prev, [key]: value }))
   }, [])
 
+  const updateProfile = useCallback((key: WizardProfileKey, value: boolean | null) => {
+    setProfile((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
   return useMemo(
-    () => ({ currentStep, state, goToStep, updateField }),
-    [currentStep, state, goToStep, updateField]
+    () => ({ currentStep, state, goToStep, updateField, profile, updateProfile }),
+    [currentStep, state, goToStep, updateField, profile, updateProfile]
   )
 }

--- a/apps/web/lib/storage/localStorage.ts
+++ b/apps/web/lib/storage/localStorage.ts
@@ -3,9 +3,12 @@
  */
 'use client'
 
+import { createInitialWizardProfile, type WizardProfile } from '../../src/modules/wizard/profile'
+
 import type { ModuleInput } from '@org/shared'
 
 const STORAGE_KEY = 'esg-wizard-state'
+const PROFILE_STORAGE_KEY = 'wizardProfile'
 
 export function loadWizardState(): ModuleInput {
   if (typeof window === 'undefined') {
@@ -36,4 +39,32 @@ export function clearWizardState(): void {
     return
   }
   window.localStorage.removeItem(STORAGE_KEY)
+}
+
+export function loadWizardProfile(): WizardProfile {
+  if (typeof window === 'undefined') {
+    return createInitialWizardProfile()
+  }
+  try {
+    const raw = window.localStorage.getItem(PROFILE_STORAGE_KEY)
+    if (!raw) {
+      return createInitialWizardProfile()
+    }
+    const parsed = JSON.parse(raw) as Partial<WizardProfile>
+    return { ...createInitialWizardProfile(), ...parsed }
+  } catch (error) {
+    console.warn('Kunne ikke læse wizardProfile', error)
+    return createInitialWizardProfile()
+  }
+}
+
+export function persistWizardProfile(profile: WizardProfile): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile))
+  } catch (error) {
+    console.warn('Kunne ikke gemme wizardProfile', error)
+  }
 }

--- a/apps/web/src/modules/wizard/PreWizardQuestionnaire.tsx
+++ b/apps/web/src/modules/wizard/PreWizardQuestionnaire.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useCallback, useState, type SyntheticEvent } from 'react'
+
+import {
+  ALL_PROFILE_KEYS,
+  countPositiveAnswers,
+  type WizardProfile,
+  type WizardProfileKey,
+  wizardProfileSections,
+} from './profile'
+import { PrimaryButton } from '../../../components/ui/PrimaryButton'
+
+type PreWizardQuestionnaireProps = {
+  profile: WizardProfile
+  onChange: (key: WizardProfileKey, value: boolean | null) => void
+  onContinue: () => void
+}
+
+export function PreWizardQuestionnaire({ profile, onChange, onContinue }: PreWizardQuestionnaireProps): JSX.Element {
+  const totalQuestions = ALL_PROFILE_KEYS.length
+  const positiveAnswers = countPositiveAnswers(profile)
+  const initialOpenSections = wizardProfileSections[0]?.id ? [wizardProfileSections[0].id] : []
+  const [openSections, setOpenSections] = useState<Set<string>>(() => new Set(initialOpenSections))
+
+  const handleSectionToggle = useCallback(
+    (sectionId: string) => (event: SyntheticEvent<HTMLDetailsElement>) => {
+      const isOpen = event.currentTarget.open
+      setOpenSections((prev) => {
+        const next = new Set(prev)
+        if (isOpen) {
+          next.add(sectionId)
+        } else {
+          next.delete(sectionId)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  return (
+    <section className="ds-stack" aria-labelledby="wizard-profile-heading">
+      <header className="ds-stack-sm">
+        <p className="ds-text-subtle">Trin 0 · Virksomhedsprofil</p>
+        <h1 id="wizard-profile-heading" className="ds-heading-lg">
+          Afgræns ESG-modulerne til din virksomheds aktiviteter
+        </h1>
+        <p className="ds-text-muted">
+          Besvar spørgsmålene nedenfor for hurtigt at vælge de områder, der er relevante for jeres ESG-beregninger.
+          Svar kan altid justeres senere via “Rediger profil”.
+        </p>
+      </header>
+
+      <div className="ds-stack-lg" role="list">
+        {wizardProfileSections.map((section) => {
+          const isOpen = openSections.has(section.id)
+          return (
+            <details
+              key={section.id}
+              className="ds-accordion"
+              role="listitem"
+              open={isOpen}
+              onToggle={handleSectionToggle(section.id)}
+            >
+              <summary className="ds-accordion__summary">
+                <div className="ds-stack-sm">
+                  <h2 className="ds-section-heading">{section.heading}</h2>
+                  <p className="ds-text-subtle">{section.description}</p>
+                </div>
+                <span aria-hidden>▾</span>
+              </summary>
+              <div className="ds-stack">
+                {section.questions.map((question) => {
+                const value = profile[question.id]
+                const yesId = `${section.id}-${question.id}-yes`
+                const noId = `${section.id}-${question.id}-no`
+
+                return (
+                  <article key={question.id} className="ds-card ds-question-card">
+                    <div className="ds-stack-sm">
+                      <div className="ds-question-card__header">
+                        <h3 className="ds-heading-sm">{question.label}</h3>
+                        <PrimaryButton
+                          variant="ghost"
+                          className="ds-button--sm"
+                          onClick={() => onChange(question.id, null)}
+                          disabled={value === null}
+                        >
+                          Spring over
+                        </PrimaryButton>
+                      </div>
+                      <p className="ds-text-subtle">{question.helpText}</p>
+                    </div>
+                    <fieldset className="ds-choice-group">
+                      <legend className="sr-only">{question.label}</legend>
+                      <label className="ds-choice" data-selected={value === true ? 'true' : undefined} htmlFor={yesId}>
+                        <input
+                          type="radio"
+                          id={yesId}
+                          name={question.id}
+                          checked={value === true}
+                          onChange={() => onChange(question.id, true)}
+                        />
+                        <span>Ja</span>
+                      </label>
+                      <label className="ds-choice" data-selected={value === false ? 'true' : undefined} htmlFor={noId}>
+                        <input
+                          type="radio"
+                          id={noId}
+                          name={question.id}
+                          checked={value === false}
+                          onChange={() => onChange(question.id, false)}
+                        />
+                        <span>Nej</span>
+                      </label>
+                    </fieldset>
+                  </article>
+                )
+                })}
+              </div>
+            </details>
+          )
+        })}
+      </div>
+
+      <footer className="ds-questionnaire-footer ds-card">
+        <div className="ds-stack-sm">
+          <h2 className="ds-heading-sm">Opsummering</h2>
+          <p className="ds-text-muted">
+            Du har valgt {positiveAnswers} ud af {totalQuestions} områder som relevante.
+          </p>
+        </div>
+        <PrimaryButton onClick={onContinue}>Fortsæt til moduler</PrimaryButton>
+      </footer>
+    </section>
+  )
+}

--- a/apps/web/src/modules/wizard/WizardOverview.tsx
+++ b/apps/web/src/modules/wizard/WizardOverview.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { isModuleRelevant, type WizardProfile } from './profile'
+
+import type { WizardStep, WizardScope } from '../../../features/wizard/steps'
+
+type WizardOverviewProps = {
+  steps: WizardStep[]
+  currentStep: number
+  onSelect: (index: number) => void
+  profile: WizardProfile
+}
+
+const scopeOrder: WizardScope[] = ['Scope 1', 'Scope 2', 'Scope 3', 'Governance']
+
+export function WizardOverview({ steps, currentStep, onSelect, profile }: WizardOverviewProps): JSX.Element {
+  const relevantCount = steps.filter((step) => isModuleRelevant(profile, step.id)).length
+
+  const stepsByScope = scopeOrder
+    .map((scope) => ({ scope, steps: steps.filter((step) => step.scope === scope) }))
+    .filter((entry) => entry.steps.length > 0)
+
+  return (
+    <nav className="ds-stack" aria-label="ESG-moduler">
+      <div className="ds-summary">
+        {relevantCount > 0 ? (
+          <p className="ds-text-subtle">{relevantCount} moduler markeret som relevante.</p>
+        ) : (
+          <p className="ds-text-subtle">Ingen moduler markeret som relevante endnu.</p>
+        )}
+      </div>
+      {stepsByScope.map(({ scope, steps: scopedSteps }) => (
+        <section key={scope} className="ds-section">
+          <div className="ds-stack-sm">
+            <h2 className="ds-section-heading">{scope}</h2>
+            <p className="ds-text-subtle">
+              {scope === 'Governance'
+                ? 'Metode- og governance-scoren anvendes i rapportens konklusion.'
+                : 'Modulerne nedenfor bidrager direkte til resultatberegningerne.'}
+            </p>
+          </div>
+          <div className="ds-pill-group" role="tablist" aria-label={`Moduler i ${scope}`}>
+            {scopedSteps.map((step) => {
+              const index = steps.findIndex((candidate) => candidate.id === step.id)
+              const isActive = index === currentStep
+              const isPlanned = step.status === 'planned'
+              const isRelevant = isModuleRelevant(profile, step.id)
+
+              return (
+                <button
+                  key={step.id}
+                  type="button"
+                  className="ds-pill"
+                  data-active={isActive ? 'true' : 'false'}
+                  data-planned={isPlanned ? 'true' : 'false'}
+                  onClick={() => onSelect(index)}
+                  aria-pressed={isActive}
+                  aria-label={`${step.label}${isPlanned ? ' (planlagt)' : ''}`}
+                  title={
+                    !isRelevant
+                      ? 'Ikke relevant for virksomheden baseret på virksomhedsprofilen.'
+                      : isPlanned
+                        ? 'Planlagt modul – beregningslogik følger.'
+                        : undefined
+                  }
+                  disabled={!isRelevant}
+                >
+                  <span>{step.label}</span>
+                  {isPlanned && <span className="ds-text-subtle">Planlagt</span>}
+                  {!isRelevant && (
+                    <span className="ds-pill__hint">Ikke relevant for virksomheden</span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </nav>
+  )
+}

--- a/apps/web/src/modules/wizard/profile.ts
+++ b/apps/web/src/modules/wizard/profile.ts
@@ -1,0 +1,382 @@
+'use client'
+
+import type { ModuleId } from '@org/shared'
+
+export type WizardProfileKey =
+  | 'hasVehicles'
+  | 'hasHeating'
+  | 'hasIndustrialProcesses'
+  | 'usesRefrigerants'
+  | 'hasBackupPower'
+  | 'hasOpenFlames'
+  | 'hasLabGas'
+  | 'usesElectricity'
+  | 'usesDistrictHeating'
+  | 'hasPpaContracts'
+  | 'hasGuaranteesOfOrigin'
+  | 'leasesWithOwnMeter'
+  | 'exportsEnergy'
+  | 'purchasesMaterials'
+  | 'hasTransportSuppliers'
+  | 'generatesWaste'
+  | 'leasesEquipment'
+  | 'shipsGoodsUpstream'
+  | 'usesGlobalFreight'
+  | 'hasConsultantsTravel'
+  | 'purchasesElectronics'
+  | 'producesProducts'
+  | 'leasesProducts'
+  | 'hasFranchisePartners'
+  | 'providesCustomerServices'
+  | 'hasProductRecycling'
+  | 'shipsFinishedGoods'
+  | 'hasInvestments'
+  | 'ownsSubsidiaries'
+  | 'operatesInternationalOffices'
+  | 'hasEsgPolicy'
+  | 'hasSupplierCode'
+  | 'doesEsgReporting'
+  | 'hasBoardOversight'
+  | 'isIso14001Certified'
+  | 'hasNetZeroTarget'
+  | 'hasDataInfrastructure'
+
+export type WizardProfile = Record<WizardProfileKey, boolean | null>
+
+export const ALL_PROFILE_KEYS: WizardProfileKey[] = [
+  'hasVehicles',
+  'hasHeating',
+  'hasIndustrialProcesses',
+  'usesRefrigerants',
+  'hasBackupPower',
+  'hasOpenFlames',
+  'hasLabGas',
+  'usesElectricity',
+  'usesDistrictHeating',
+  'hasPpaContracts',
+  'hasGuaranteesOfOrigin',
+  'leasesWithOwnMeter',
+  'exportsEnergy',
+  'purchasesMaterials',
+  'hasTransportSuppliers',
+  'generatesWaste',
+  'leasesEquipment',
+  'shipsGoodsUpstream',
+  'usesGlobalFreight',
+  'hasConsultantsTravel',
+  'purchasesElectronics',
+  'producesProducts',
+  'leasesProducts',
+  'hasFranchisePartners',
+  'providesCustomerServices',
+  'hasProductRecycling',
+  'shipsFinishedGoods',
+  'hasInvestments',
+  'ownsSubsidiaries',
+  'operatesInternationalOffices',
+  'hasEsgPolicy',
+  'hasSupplierCode',
+  'doesEsgReporting',
+  'hasBoardOversight',
+  'isIso14001Certified',
+  'hasNetZeroTarget',
+  'hasDataInfrastructure',
+]
+
+export function createInitialWizardProfile(): WizardProfile {
+  return ALL_PROFILE_KEYS.reduce<WizardProfile>((profile, key) => {
+    profile[key] = null
+    return profile
+  }, {} as WizardProfile)
+}
+
+export type WizardProfileQuestion = {
+  id: WizardProfileKey
+  label: string
+  helpText: string
+}
+
+export type WizardProfileSection = {
+  id: string
+  heading: string
+  description: string
+  questions: WizardProfileQuestion[]
+}
+
+export const wizardProfileSections: WizardProfileSection[] = [
+  {
+    id: 'scope-1',
+    heading: 'Scope 1 – Direkte emissioner',
+    description: 'Identificer aktiviteter med direkte udledninger fra egne køretøjer og anlæg.',
+    questions: [
+      {
+        id: 'hasVehicles',
+        label: 'Har virksomheden egne køretøjer (firmabiler, varevogne, lastbiler, maskiner)?',
+        helpText: 'Omfatter alle motordrevne køretøjer der ejes eller leases af virksomheden.',
+      },
+      {
+        id: 'hasHeating',
+        label: 'Har virksomheden eget varme- eller kedelanlæg (fx naturgas, olie, biogas)?',
+        helpText: 'Stationære forbrændingskilder som fyr, kedler og ovne til opvarmning af bygninger.',
+      },
+      {
+        id: 'hasIndustrialProcesses',
+        label: 'Udfører virksomheden industrielle processer, der udleder gasser (cement, metal, kemi, fødevareproduktion)?',
+        helpText: 'Processer med kemiske reaktioner eller høje temperaturer som frigiver CO₂ eller andre gasser.',
+      },
+      {
+        id: 'usesRefrigerants',
+        label: 'Anvendes der kølemidler eller andre flygtige emissioner (fx køleanlæg, aircondition, varmevekslere)?',
+        helpText: 'Gælder også mindre anlæg som aircondition og kølediske med potentielle lækager.',
+      },
+      {
+        id: 'hasBackupPower',
+        label: 'Har virksomheden nødgeneratorer eller backupstrøm (diesel eller benzin)?',
+        helpText: 'Reservedieselanlæg eller generatorer til nødstrøm ved strømafbrydelse.',
+      },
+      {
+        id: 'hasOpenFlames',
+        label: 'Har virksomheden produktion med åbne flammer, brændere eller svejsning?',
+        helpText: 'Fx glas- og metalbearbejdning, svejseværksteder og andre højtemperaturprocesser.',
+      },
+      {
+        id: 'hasLabGas',
+        label: 'Har virksomheden laboratorieudstyr med gasforbrug?',
+        helpText: 'Laboratorier og testfaciliteter med gasbrændere eller specialgasudstyr.',
+      },
+    ],
+  },
+  {
+    id: 'scope-2',
+    heading: 'Scope 2 – Indirekte energiforbrug',
+    description: 'Kortlæg energiforbrug og dokumentationsmuligheder for indkøbt energi.',
+    questions: [
+      {
+        id: 'usesElectricity',
+        label: 'Forbruger virksomheden elektricitet i egne lokaler?',
+        helpText: 'Fx kontorer, butikker, produktion eller datacentre med eget elforbrug.',
+      },
+      {
+        id: 'usesDistrictHeating',
+        label: 'Forbruger virksomheden fjernvarme, damp eller køling?',
+        helpText: 'Indkøbt varme- og køleleverancer fra energiselskaber eller ejendomsforvaltning.',
+      },
+      {
+        id: 'hasPpaContracts',
+        label: 'Har virksomheden kontrakter på vedvarende energi (PPA’er – fysisk, virtuel eller time-matched)?',
+        helpText: 'Power Purchase Agreements for direkte eller virtuel levering af grøn strøm.',
+      },
+      {
+        id: 'hasGuaranteesOfOrigin',
+        label: 'Har virksomheden dokumenteret vedvarende energi via oprindelsesgarantier?',
+        helpText: 'Inkluderer køb af certifikater til at dokumentere grøn strøm.',
+      },
+      {
+        id: 'leasesWithOwnMeter',
+        label: 'Lejer virksomheden lokaler med eget elforbrug (separat elmåler)?',
+        helpText: 'Fx kontorer i lejemål hvor virksomheden selv afregner elforbrug.',
+      },
+      {
+        id: 'exportsEnergy',
+        label: 'Eksporterer virksomheden selv energi (fx solceller, elproduktion)?',
+        helpText: 'Salg af egenproduceret energi til nettet eller andre parter.',
+      },
+    ],
+  },
+  {
+    id: 'scope-3-upstream',
+    heading: 'Scope 3 – Upstream aktiviteter',
+    description: 'Vurder emissioner i forsyningskæden før produkter eller ydelser forlader virksomheden.',
+    questions: [
+      {
+        id: 'purchasesMaterials',
+        label: 'Køber virksomheden råmaterialer eller halvfabrikata?',
+        helpText: 'Inkluderer alt materialeindkøb til produktion, projekter eller salg.',
+      },
+      {
+        id: 'hasTransportSuppliers',
+        label: 'Har virksomheden leverandører med transportydelser?',
+        helpText: 'Eksterne speditører, logistikpartnere eller transportleverandører.',
+      },
+      {
+        id: 'generatesWaste',
+        label: 'Genererer virksomheden affald fra produktion, kontor eller byggeprojekter?',
+        helpText: 'Sorterede eller usorterede affaldsfraktioner fra den daglige drift.',
+      },
+      {
+        id: 'leasesEquipment',
+        label: 'Lejer virksomheden produktionsudstyr eller kontormaskiner?',
+        helpText: 'Kort- eller langtidsleje af maskiner, køretøjer, kontorudstyr eller værktøj.',
+      },
+      {
+        id: 'shipsGoodsUpstream',
+        label: 'Transporterer virksomheden varer til kunder eller distributører?',
+        helpText: 'Transport inden varerne når slutkunden, fx til distributionscentre.',
+      },
+      {
+        id: 'usesGlobalFreight',
+        label: 'Bruger virksomheden fragt, fly eller søtransport i forsyningskæden?',
+        helpText: 'Internationale leverancer med fly, skib eller langdistance transport.',
+      },
+      {
+        id: 'hasConsultantsTravel',
+        label: 'Har virksomheden konsulenter eller underleverandører med arbejdsrejser?',
+        helpText: 'Eksterne samarbejdspartnere der rejser på vegne af virksomheden.',
+      },
+      {
+        id: 'purchasesElectronics',
+        label: 'Køber virksomheden IT-udstyr eller elektronik regelmæssigt?',
+        helpText: 'Computere, telefoner, netværksudstyr og andet elektronikindkøb.',
+      },
+    ],
+  },
+  {
+    id: 'scope-3-downstream',
+    heading: 'Scope 3 – Downstream aktiviteter',
+    description: 'Forstå emissioner efter produktet forlader virksomheden, inkl. kunder og investeringer.',
+    questions: [
+      {
+        id: 'producesProducts',
+        label: 'Producerer eller sælger virksomheden fysiske produkter?',
+        helpText: 'Produktion eller salg af varer med efterfølgende brug hos kunder.',
+      },
+      {
+        id: 'leasesProducts',
+        label: 'Lejer virksomheden produkter ud (leasing, udlejning, deleordninger)?',
+        helpText: 'Produktudlejning hvor virksomheden beholder ejerskabet.',
+      },
+      {
+        id: 'hasFranchisePartners',
+        label: 'Har virksomheden franchisetagere eller partnere, der videresælger?',
+        helpText: 'Franchise- eller partnernetværk med egen drift under virksomhedens brand.',
+      },
+      {
+        id: 'providesCustomerServices',
+        label: 'Tilbyder virksomheden service eller support til kundernes drift?',
+        helpText: 'Serviceaftaler, vedligehold eller konsulentydelser efter salg.',
+      },
+      {
+        id: 'hasProductRecycling',
+        label: 'Har virksomheden genbrugs- eller affaldsaktiviteter relateret til produkter?',
+        helpText: 'Tilbagekaldelse, take-back-ordninger eller produktgenanvendelse.',
+      },
+      {
+        id: 'shipsFinishedGoods',
+        label: 'Transporterer virksomheden færdige varer til kunder (downstream logistik)?',
+        helpText: 'Distribution af færdige produkter til slutkunder eller forhandlere.',
+      },
+      {
+        id: 'hasInvestments',
+        label: 'Har virksomheden langsigtede investeringer, fonde eller finansielle aktiver?',
+        helpText: 'Kapitalplaceringer med væsentlige klimarelaterede effekter.',
+      },
+      {
+        id: 'ownsSubsidiaries',
+        label: 'Er virksomheden medejer af datterselskaber med udledninger?',
+        helpText: 'Delvist ejede selskaber eller joint ventures med driftsaktiviteter.',
+      },
+      {
+        id: 'operatesInternationalOffices',
+        label: 'Driver virksomheden kontorer i andre lande (rejser, transport, strøm)?',
+        helpText: 'Udenlandske aktiviteter med rejser og faciliteter uden for hjemlandet.',
+      },
+    ],
+  },
+  {
+    id: 'governance',
+    heading: 'Governance og rapportering',
+    description: 'Vurdér modenhed i styring, målsætninger og rapporteringspraksis.',
+    questions: [
+      {
+        id: 'hasEsgPolicy',
+        label: 'Har virksomheden en skriftlig ESG- eller bæredygtighedspolitik?',
+        helpText: 'Overordnede politikker eller strategier for ESG-indsatsen.',
+      },
+      {
+        id: 'hasSupplierCode',
+        label: 'Har virksomheden retningslinjer for leverandørstyring (Code of Conduct)?',
+        helpText: 'Dokumenterede krav eller aftaler med leverandører om ansvarlig drift.',
+      },
+      {
+        id: 'doesEsgReporting',
+        label: 'Udfører virksomheden ESG-rapportering allerede (fx CSRD, GHG)?',
+        helpText: 'Formelle rapporter eller offentliggørelser af ESG-nøgletal.',
+      },
+      {
+        id: 'hasBoardOversight',
+        label: 'Har virksomheden bestyrelse, CSR-ansvarlig eller ESG-udvalg?',
+        helpText: 'Organisatorisk forankring af ESG-arbejdet i ledelsen.',
+      },
+      {
+        id: 'isIso14001Certified',
+        label: 'Er virksomheden ISO 14001- eller EMAS-certificeret?',
+        helpText: 'Certificeringer for miljøledelsessystemer og løbende forbedringer.',
+      },
+      {
+        id: 'hasNetZeroTarget',
+        label: 'Har virksomheden et mål for CO₂-neutralitet eller energireduktion?',
+        helpText: 'Officielle målsætninger for emissioner eller energiforbrug.',
+      },
+      {
+        id: 'hasDataInfrastructure',
+        label: 'Har virksomheden datainfrastruktur til rapportering (IT-systemer, API’er)?',
+        helpText: 'Systemer og processer til indsamling af ESG-data på tværs af organisationen.',
+      },
+    ],
+  },
+]
+
+const moduleDependencies: Partial<Record<ModuleId, WizardProfileKey[]>> = {
+  A1: ['hasHeating', 'hasIndustrialProcesses', 'hasBackupPower', 'hasOpenFlames', 'hasLabGas'],
+  A2: ['hasVehicles'],
+  A3: ['hasIndustrialProcesses'],
+  A4: ['usesRefrigerants'],
+  B1: ['usesElectricity', 'leasesWithOwnMeter'],
+  B2: ['hasHeating', 'usesDistrictHeating'],
+  B3: ['usesDistrictHeating'],
+  B4: ['usesDistrictHeating'],
+  B5: ['usesElectricity', 'usesDistrictHeating', 'exportsEnergy'],
+  B6: ['usesElectricity'],
+  B7: ['hasGuaranteesOfOrigin'],
+  B8: ['exportsEnergy'],
+  B9: ['hasPpaContracts'],
+  B10: ['hasPpaContracts'],
+  B11: ['hasPpaContracts', 'hasGuaranteesOfOrigin'],
+  C1: ['operatesInternationalOffices'],
+  C2: ['hasConsultantsTravel', 'operatesInternationalOffices'],
+  C3: ['usesElectricity', 'usesDistrictHeating', 'hasBackupPower'],
+  C4: ['hasTransportSuppliers', 'shipsGoodsUpstream'],
+  C5: ['generatesWaste'],
+  C6: ['leasesEquipment'],
+  C7: ['shipsFinishedGoods'],
+  C8: ['leasesProducts'],
+  C9: ['producesProducts'],
+  C10: ['leasesEquipment', 'leasesProducts'],
+  C11: ['leasesProducts'],
+  C12: ['hasFranchisePartners', 'providesCustomerServices'],
+  C13: ['hasInvestments'],
+  C14: ['hasProductRecycling'],
+  C15: ['producesProducts', 'hasInvestments'],
+  D1: ['hasEsgPolicy', 'doesEsgReporting', 'hasBoardOversight', 'hasNetZeroTarget'],
+}
+
+export function isModuleRelevant(profile: WizardProfile, moduleId: ModuleId): boolean {
+  const dependencies = moduleDependencies[moduleId]
+  if (!dependencies || dependencies.length === 0) {
+    return true
+  }
+  return dependencies.some((key) => profile[key] === true)
+}
+
+export function countPositiveAnswers(profile: WizardProfile): number {
+  return ALL_PROFILE_KEYS.reduce((count, key) => (profile[key] ? count + 1 : count), 0)
+}
+
+export function hasAnyAnswer(profile: WizardProfile): boolean {
+  return ALL_PROFILE_KEYS.some((key) => profile[key] !== null)
+}
+
+export function findFirstRelevantStepIndex(steps: { id: ModuleId }[], profile: WizardProfile): number {
+  const index = steps.findIndex((step) => isModuleRelevant(profile, step.id))
+  return index === -1 ? 0 : index
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1,0 +1,453 @@
+:root {
+  --color-primary: #0a7d55;
+  --color-primary-strong: #064f37;
+  --color-primary-weak: #c1e7da;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f4f7f6;
+  --color-surface-strong: #e9f2ee;
+  --color-border: #d0d7d5;
+  --color-border-strong: #9eb5af;
+  --color-text: #132321;
+  --color-text-muted: #4a5b59;
+  --color-text-subtle: #6f7f7d;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --shadow-sm: 0 4px 12px rgba(10, 125, 85, 0.08);
+  --shadow-md: 0 12px 32px rgba(10, 125, 85, 0.12);
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.5rem;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+}
+
+a {
+  color: inherit;
+}
+
+.ds-page {
+  margin: 0 auto;
+  width: min(100%, 1100px);
+  padding: var(--space-6) var(--space-5) var(--space-7);
+  display: grid;
+  gap: var(--space-6);
+  align-content: start;
+}
+
+.ds-stack {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ds-stack-sm {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ds-stack-lg {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.ds-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ds-accordion {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.ds-accordion__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.ds-accordion__summary [aria-hidden] {
+  transition: transform 0.2s ease;
+}
+
+.ds-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+
+.ds-accordion[open] > .ds-accordion__summary {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ds-accordion[open] > .ds-accordion__summary [aria-hidden] {
+  transform: rotate(180deg);
+}
+
+.ds-accordion > .ds-stack {
+  padding: var(--space-5);
+  background: var(--color-surface);
+}
+
+.ds-question-card {
+  gap: var(--space-4);
+}
+
+.ds-question-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.ds-choice-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ds-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ds-choice input {
+  accent-color: var(--color-primary);
+}
+
+.ds-choice[data-selected='true'] {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(10, 125, 85, 0.15);
+  background: var(--color-surface-strong);
+}
+
+.ds-choice input:focus-visible + span {
+  outline: 2px solid rgba(10, 125, 85, 0.4);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.ds-button--sm {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  box-shadow: none;
+}
+
+.ds-button--sm[data-variant='ghost'] {
+  border-color: var(--color-border);
+}
+
+.ds-questionnaire-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.ds-pill__hint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-subtle);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ds-card--muted {
+  background: var(--color-surface-muted);
+  border-style: dashed;
+  color: var(--color-text-muted);
+}
+
+.ds-text-muted {
+  color: var(--color-text-muted);
+}
+
+.ds-text-subtle {
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-sm);
+}
+
+.ds-heading-sm {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.ds-heading-lg {
+  margin: 0;
+  font-size: var(--font-size-xl);
+}
+
+.ds-value {
+  margin: 0;
+  font-size: calc(var(--font-size-xl) + 0.25rem);
+  font-weight: 600;
+}
+
+.ds-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.ds-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.ds-pill {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--color-primary-weak);
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+}
+
+.ds-pill[data-active='true'] {
+  border-color: var(--color-primary-strong);
+  background: var(--color-surface);
+  color: var(--color-primary-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.ds-pill[data-planned='true'] {
+  opacity: 0.72;
+}
+
+.ds-pill[disabled] {
+  background: var(--color-surface-muted);
+  border-color: var(--color-border);
+  color: var(--color-text-subtle);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.ds-pill[disabled]:hover {
+  transform: none;
+}
+
+.ds-pill:hover {
+  transform: translateY(-1px);
+}
+
+.ds-section-heading {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+}
+
+.ds-section {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ds-form {
+  display: grid;
+  gap: var(--space-4);
+  max-width: 32rem;
+}
+
+.ds-field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ds-field label {
+  font-weight: 600;
+}
+
+.ds-input {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  font-size: var(--font-size-base);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ds-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(10, 125, 85, 0.15);
+}
+
+.ds-input[data-invalid='true'] {
+  border-color: #cf3728;
+  box-shadow: 0 0 0 2px rgba(207, 55, 40, 0.2);
+}
+
+.ds-field-help {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-subtle);
+}
+
+.ds-error {
+  color: #b42318;
+  font-size: var(--font-size-sm);
+}
+
+.ds-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.ds-hero {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: var(--space-6) var(--space-5);
+  text-align: center;
+  gap: var(--space-4);
+}
+
+.ds-constrain {
+  width: min(100%, 42rem);
+  margin: 0 auto;
+}
+
+.ds-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.ds-button:hover:not([disabled]) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  background: var(--color-primary-strong);
+}
+
+.ds-button:focus-visible {
+  outline: 3px solid rgba(10, 125, 85, 0.3);
+  outline-offset: 2px;
+}
+
+.ds-button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.ds-button[data-variant='ghost'] {
+  background: var(--color-surface);
+  color: var(--color-primary-strong);
+  border: 1px solid var(--color-border);
+  box-shadow: none;
+}
+
+.ds-button[data-variant='ghost']:hover:not([disabled]) {
+  background: var(--color-surface-strong);
+  box-shadow: none;
+}
+
+.ds-divider {
+  height: 1px;
+  background: var(--color-border);
+  border: none;
+}
+
+.ds-summary {
+  padding: var(--space-3);
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-md);
+}
+
+.ds-code {
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, SFMono-Regular, SFMono, Consolas, 'Liberation Mono', monospace;
+  font-size: var(--font-size-sm);
+}
+
+.ds-scroll-panel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  overflow: hidden;
+}
+
+.ds-scroll-panel iframe,
+.ds-scroll-panel canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.ds-scroll-panel[data-size='tall'] {
+  height: 70vh;
+}
+
+@media (max-width: 768px) {
+  .ds-page {
+    padding: var(--space-5) var(--space-4) var(--space-6);
+  }
+
+  .ds-pill-group {
+    gap: var(--space-1);
+  }
+
+  .ds-pill {
+    width: 100%;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a company profile questionnaire that gathers module relevancy answers and persists them to `wizardProfile`
- integrate the wizard navigation with profile filtering, edit entry point and storage debouncing
- extend design-system utilities for accordion, choice groups and disabled pills while documenting the workflow in `AI_GUIDE.md`

## Testing
- CI=1 pnpm --filter @org/web build
- CI=1 pnpm --filter @org/web test

------
https://chatgpt.com/codex/tasks/task_e_68e0f5f4393c83259ca4a159d911c8f0