### PR TITLE
fix: sanitize wizard profile storage entries

### DIFF
--- a/apps/web/features/wizard/__tests__/useWizard.types.test.ts
+++ b/apps/web/features/wizard/__tests__/useWizard.types.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expectTypeOf } from 'vitest'
+
+import type {
+  ActiveProfileState,
+  WizardProfileEntry,
+  WizardProfileId,
+  WizardProfileMap,
+  WizardProfileSummary,
+  WizardState,
+} from '../useWizard'
+import type { WizardProfile } from '../../../src/modules/wizard/profile'
+import type { ModuleInput } from '@org/shared'
+
+describe('useWizard type exports', () => {
+  it('exposes WizardProfileId as a string alias', () => {
+    expectTypeOf<WizardProfileId>().toMatchTypeOf<string>()
+  })
+
+  it('describes WizardProfileEntry shape with state and profile', () => {
+    expectTypeOf<WizardProfileEntry['state']>().toMatchTypeOf<ModuleInput>()
+    expectTypeOf<WizardProfileEntry['profile']>().toMatchTypeOf<WizardProfile>()
+  })
+
+  it('maps WizardProfileMap ids to entries', () => {
+    expectTypeOf<WizardProfileMap>().toMatchTypeOf<Record<string, WizardProfileEntry>>()
+  })
+
+  it('ActiveProfileState combines id, state and profile', () => {
+    expectTypeOf<ActiveProfileState>().toMatchTypeOf<{
+      id: string
+      name: string
+      state: WizardState
+      profile: WizardProfile
+    }>()
+  })
+
+  it('WizardProfileSummary exposes summary data', () => {
+    expectTypeOf<WizardProfileSummary>().toMatchTypeOf<{
+      id: string
+      name: string
+      isActive: boolean
+    }>()
+  })
+})

--- a/apps/web/features/wizard/useWizard.ts
+++ b/apps/web/features/wizard/useWizard.ts
@@ -7,67 +7,104 @@
 import type { ModuleInput } from '@org/shared'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  loadWizardProfile,
-  loadWizardState,
-  persistWizardProfile,
-  persistWizardState,
+  loadWizardStorage,
+  persistWizardStorage,
+  type PersistedWizardProfile,
+  type PersistedWizardStorage,
 } from '../../lib/storage/localStorage'
 import { wizardSteps } from './steps'
 import type { WizardProfileKey } from '../../src/modules/wizard/profile'
-import { type WizardProfile } from '../../src/modules/wizard/profile'
+import { createInitialWizardProfile, type WizardProfile } from '../../src/modules/wizard/profile'
 
 export type WizardState = ModuleInput
+
+export type WizardProfileId = string
+
+export type WizardProfileEntry = PersistedWizardProfile
+
+export type WizardProfileMap = Record<WizardProfileId, WizardProfileEntry>
+
+export type ActiveProfileState = {
+  id: WizardProfileId
+  name: string
+  state: WizardState
+  profile: WizardProfile
+}
+
+export type WizardProfileSummary = {
+  id: WizardProfileId
+  name: string
+  isActive: boolean
+}
 
 type WizardHook = {
   currentStep: number
   state: WizardState
+  activeState: WizardState
+  profile: WizardProfile
+  activeProfile: ActiveProfileState
+  profiles: WizardProfileMap
+  profileSummaries: WizardProfileSummary[]
+  activeProfileId: WizardProfileId
   goToStep: (index: number) => void
   updateField: (key: string, value: unknown) => void
-  profile: WizardProfile
   updateProfile: (key: WizardProfileKey, value: boolean | null) => void
+  createProfile: (name?: string) => void
+  switchProfile: (profileId: WizardProfileId) => void
+  renameProfile: (profileId: WizardProfileId, name: string) => void
+  duplicateProfile: (profileId: WizardProfileId) => void
+  deleteProfile: (profileId: WizardProfileId) => void
 }
 
 const AUTOSAVE_DELAY = 800
 const DEFAULT_STEP_INDEX = wizardSteps.findIndex((step) => step.status === 'ready')
 const INITIAL_STEP = DEFAULT_STEP_INDEX === -1 ? 0 : DEFAULT_STEP_INDEX
 
+function generateProfileId(): WizardProfileId {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `profile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function cloneModuleInput(input: ModuleInput): ModuleInput {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(input)
+    } catch (error) {
+      console.warn('Kunne ikke structuredClone wizard-state, falder tilbage til JSON-clone', error)
+    }
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(input)) as ModuleInput
+  } catch (error) {
+    console.warn('Kunne ikke JSON-clone wizard-state, genbruger eksisterende reference', error)
+    return input
+  }
+}
+
 export function useWizard(): WizardHook {
   const [currentStep, setCurrentStep] = useState(INITIAL_STEP)
-  const [state, setState] = useState<WizardState>(() => loadWizardState())
-  const [profile, setProfile] = useState<WizardProfile>(() => loadWizardProfile())
-  const stateRef = useRef(state)
-  const profileRef = useRef(profile)
+  const [storage, setStorage] = useState<PersistedWizardStorage>(() => loadWizardStorage())
+  const storageRef = useRef(storage)
 
   useEffect(() => {
-    stateRef.current = state
-  }, [state])
-
-  useEffect(() => {
-    profileRef.current = profile
-  }, [profile])
+    storageRef.current = storage
+  }, [storage])
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      persistWizardState(state)
+      persistWizardStorage(storageRef.current)
     }, AUTOSAVE_DELAY)
     return () => {
       window.clearTimeout(timer)
     }
-  }, [state])
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      persistWizardProfile(profile)
-    }, AUTOSAVE_DELAY)
-    return () => {
-      window.clearTimeout(timer)
-    }
-  }, [profile])
+  }, [storage])
 
   useEffect(() => {
     const handleBeforeUnload = () => {
-      persistWizardState(stateRef.current)
-      persistWizardProfile(profileRef.current)
+      persistWizardStorage(storageRef.current)
     }
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => {
@@ -80,15 +117,215 @@ export function useWizard(): WizardHook {
   }, [])
 
   const updateField = useCallback((key: string, value: unknown) => {
-    setState((prev) => ({ ...prev, [key]: value }))
+    setStorage((prev) => {
+      const active = prev.profiles[prev.activeProfileId]
+      if (!active) {
+        return prev
+      }
+      return {
+        ...prev,
+        profiles: {
+          ...prev.profiles,
+          [prev.activeProfileId]: {
+            ...active,
+            state: { ...active.state, [key]: value },
+            updatedAt: Date.now(),
+          },
+        },
+      }
+    })
   }, [])
 
   const updateProfile = useCallback((key: WizardProfileKey, value: boolean | null) => {
-    setProfile((prev) => ({ ...prev, [key]: value }))
+    setStorage((prev) => {
+      const active = prev.profiles[prev.activeProfileId]
+      if (!active) {
+        return prev
+      }
+      return {
+        ...prev,
+        profiles: {
+          ...prev.profiles,
+          [prev.activeProfileId]: {
+            ...active,
+            profile: { ...active.profile, [key]: value },
+            updatedAt: Date.now(),
+          },
+        },
+      }
+    })
   }, [])
 
-  return useMemo(
-    () => ({ currentStep, state, goToStep, updateField, profile, updateProfile }),
-    [currentStep, state, goToStep, updateField, profile, updateProfile]
-  )
+  const createProfile = useCallback((name?: string) => {
+    setStorage((prev) => {
+      const id = generateProfileId()
+      const profileName = name?.trim() || `Profil ${Object.keys(prev.profiles).length + 1}`
+      const now = Date.now()
+      const newProfile: PersistedWizardProfile = {
+        id,
+        name: profileName,
+        state: {},
+        profile: createInitialWizardProfile(),
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      return {
+        activeProfileId: id,
+        profiles: { ...prev.profiles, [id]: newProfile },
+      }
+    })
+  }, [])
+
+  const switchProfile = useCallback((profileId: WizardProfileId) => {
+    setStorage((prev) => {
+      if (!prev.profiles[profileId] || prev.activeProfileId === profileId) {
+        return prev
+      }
+      return {
+        ...prev,
+        activeProfileId: profileId,
+      }
+    })
+  }, [])
+
+  const renameProfile = useCallback((profileId: WizardProfileId, name: string) => {
+    setStorage((prev) => {
+      const target = prev.profiles[profileId]
+      if (!target) {
+        return prev
+      }
+      const trimmed = name.trim()
+      if (trimmed.length === 0 || trimmed === target.name) {
+        return prev
+      }
+      return {
+        ...prev,
+        profiles: {
+          ...prev.profiles,
+          [profileId]: { ...target, name: trimmed, updatedAt: Date.now() },
+        },
+      }
+    })
+  }, [])
+
+  const duplicateProfile = useCallback((profileId: WizardProfileId) => {
+    setStorage((prev) => {
+      const target = prev.profiles[profileId]
+      if (!target) {
+        return prev
+      }
+      const id = generateProfileId()
+      const now = Date.now()
+      const clone: PersistedWizardProfile = {
+        id,
+        name: `${target.name} (kopi)`,
+        state: cloneModuleInput(target.state),
+        profile: { ...target.profile },
+        createdAt: now,
+        updatedAt: now,
+      }
+      return {
+        activeProfileId: id,
+        profiles: { ...prev.profiles, [id]: clone },
+      }
+    })
+  }, [])
+
+  const deleteProfile = useCallback((profileId: WizardProfileId) => {
+    setStorage((prev) => {
+      if (!prev.profiles[profileId]) {
+        return prev
+      }
+
+      const nextProfiles = { ...prev.profiles }
+      delete nextProfiles[profileId]
+
+      if (Object.keys(nextProfiles).length === 0) {
+        const id = generateProfileId()
+        const now = Date.now()
+        nextProfiles[id] = {
+          id,
+          name: 'Profil 1',
+          state: {},
+          profile: createInitialWizardProfile(),
+          createdAt: now,
+          updatedAt: now,
+        }
+        return {
+          activeProfileId: id,
+          profiles: nextProfiles,
+        }
+      }
+
+      const fallbackId = Object.keys(nextProfiles)[0] ?? prev.activeProfileId
+      const nextActiveId = profileId === prev.activeProfileId ? fallbackId : prev.activeProfileId
+
+      return {
+        activeProfileId: nextActiveId,
+        profiles: nextProfiles,
+      }
+    })
+  }, [])
+
+  const activeProfile = storage.profiles[storage.activeProfileId]
+
+  const value = useMemo(() => {
+    const fallbackProfile: PersistedWizardProfile =
+      activeProfile ?? {
+        id: storage.activeProfileId,
+        name: 'Profil 1',
+        state: {},
+        profile: createInitialWizardProfile(),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }
+
+    const active: ActiveProfileState = {
+      id: fallbackProfile.id,
+      name: fallbackProfile.name,
+      state: fallbackProfile.state,
+      profile: fallbackProfile.profile,
+    }
+
+    const summaries: WizardProfileSummary[] = Object.values(storage.profiles).map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      isActive: entry.id === fallbackProfile.id,
+    }))
+
+    return {
+      currentStep,
+      state: active.state,
+      activeState: active.state,
+      goToStep,
+      updateField,
+      profile: active.profile,
+      updateProfile,
+      activeProfile: active,
+      profiles: storage.profiles,
+      profileSummaries: summaries,
+      activeProfileId: active.id,
+      createProfile,
+      switchProfile,
+      renameProfile,
+      duplicateProfile,
+      deleteProfile,
+    }
+  }, [
+    activeProfile,
+    createProfile,
+    currentStep,
+    deleteProfile,
+    duplicateProfile,
+    goToStep,
+    renameProfile,
+    storage.profiles,
+    storage.activeProfileId,
+    switchProfile,
+    updateField,
+    updateProfile,
+  ])
+
+  return value
 }

--- a/apps/web/lib/storage/__tests__/migration.test.ts
+++ b/apps/web/lib/storage/__tests__/migration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, beforeEach, it } from 'vitest'
+
+import {
+  loadWizardProfile,
+  loadWizardState,
+  loadWizardStorage,
+} from '../localStorage'
+
+const LEGACY_STATE_KEY = 'esg-wizard-state'
+const LEGACY_PROFILE_KEY = 'wizardProfile'
+
+describe('wizard storage migration', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('migrates legacy keys into combined storage', () => {
+    const legacyState = { moduleA: { answer: 42 } }
+    const legacyProfile = { hasVehicles: true }
+
+    window.localStorage.setItem(LEGACY_STATE_KEY, JSON.stringify(legacyState))
+    window.localStorage.setItem(LEGACY_PROFILE_KEY, JSON.stringify(legacyProfile))
+
+    const state = loadWizardState()
+    const profile = loadWizardProfile()
+    const storage = loadWizardStorage()
+
+    expect(state).toStrictEqual(legacyState)
+    expect(profile.hasVehicles).toBe(true)
+
+    expect(storage.activeProfileId).toBeTruthy()
+    const active = storage.profiles[storage.activeProfileId]
+    expect(active).toBeDefined()
+    if (!active) {
+      throw new Error('Active profile was not created during migration')
+    }
+    expect(active.state).toStrictEqual(legacyState)
+    expect(active.profile.hasVehicles).toBe(true)
+
+    expect(window.localStorage.getItem(LEGACY_STATE_KEY)).toBeNull()
+    expect(window.localStorage.getItem(LEGACY_PROFILE_KEY)).toBeNull()
+  })
+
+  it('normalises invalid profile values when loading combined storage', () => {
+    const invalidStorage = {
+      activeProfileId: 'invalid',
+      profiles: {
+        invalid: {
+          id: 'invalid',
+          name: 'Invalid profil',
+          state: { nested: { value: 1 } },
+          profile: {
+            hasVehicles: 'ja tak',
+            hasHeating: true,
+            unknownKey: true,
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    }
+
+    window.localStorage.setItem('esg-wizard-profiles', JSON.stringify(invalidStorage))
+
+    const storage = loadWizardStorage()
+
+    const active = storage.profiles[storage.activeProfileId]
+    expect(active).toBeDefined()
+    if (!active) {
+      throw new Error('Active profile blev ikke normaliseret korrekt')
+    }
+
+    expect(active.profile.hasHeating).toBe(true)
+    expect(active.profile.hasVehicles).toBeNull()
+    expect((active.profile as Record<string, unknown>)['unknownKey']).toBeUndefined()
+  })
+})

--- a/apps/web/lib/storage/localStorage.ts
+++ b/apps/web/lib/storage/localStorage.ts
@@ -3,35 +3,230 @@
  */
 'use client'
 
-import { createInitialWizardProfile, type WizardProfile } from '../../src/modules/wizard/profile'
+import { ALL_PROFILE_KEYS, createInitialWizardProfile, type WizardProfile } from '../../src/modules/wizard/profile'
 
 import type { ModuleInput } from '@org/shared'
 
-const STORAGE_KEY = 'esg-wizard-state'
-const PROFILE_STORAGE_KEY = 'wizardProfile'
+type UnknownRecord = Record<string, unknown>
+
+export type PersistedWizardProfile = {
+  id: string
+  name: string
+  state: ModuleInput
+  profile: WizardProfile
+  createdAt: number
+  updatedAt: number
+}
+
+export type PersistedWizardStorage = {
+  activeProfileId: string
+  profiles: Record<string, PersistedWizardProfile>
+}
+
+const STORAGE_KEY = 'esg-wizard-profiles'
+const LEGACY_STATE_KEY = 'esg-wizard-state'
+const LEGACY_PROFILE_KEY = 'wizardProfile'
+
+const DEFAULT_PROFILE_ID = 'default'
+const DEFAULT_PROFILE_NAME = 'Profil 1'
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function safeParse<T>(raw: string | null): T | undefined {
+  if (!raw) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(raw) as T
+  } catch (error) {
+    console.warn('Kunne ikke parse localStorage-indhold', error)
+    return undefined
+  }
+}
+
+function sanitiseWizardProfile(value: unknown): WizardProfile {
+  const base = createInitialWizardProfile()
+
+  if (!isRecord(value)) {
+    return base
+  }
+
+  const record = value as UnknownRecord
+
+  for (const key of ALL_PROFILE_KEYS) {
+    const raw = record[key]
+    if (raw === true || raw === false || raw === null) {
+      base[key] = raw
+    }
+  }
+
+  return base
+}
+
+function createProfileEntry(id: string, name: string, state: ModuleInput = {} as ModuleInput): PersistedWizardProfile {
+  const now = Date.now()
+  return {
+    id,
+    name,
+    state,
+    profile: createInitialWizardProfile(),
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function normaliseProfile(id: string, value: unknown, fallbackName: string): PersistedWizardProfile {
+  const base = createProfileEntry(id, fallbackName)
+
+  if (!isRecord(value)) {
+    return base
+  }
+
+  const record = value as UnknownRecord
+  const profileName =
+    typeof record['name'] === 'string' && record['name'].trim().length > 0 ? (record['name'] as string) : base.name
+  const state = isRecord(record['state']) ? (record['state'] as ModuleInput) : base.state
+  const parsedProfile = sanitiseWizardProfile(record['profile'])
+  const createdAt = typeof record['createdAt'] === 'number' ? (record['createdAt'] as number) : base.createdAt
+  const updatedAt = typeof record['updatedAt'] === 'number' ? (record['updatedAt'] as number) : createdAt
+
+  return {
+    id,
+    name: profileName,
+    state,
+    profile: parsedProfile,
+    createdAt,
+    updatedAt,
+  }
+}
+
+function normaliseStorage(raw: unknown): PersistedWizardStorage | undefined {
+  if (!isRecord(raw)) {
+    return undefined
+  }
+
+  const storageRecord = raw as UnknownRecord
+  const profilesRaw = storageRecord['profiles']
+  if (!isRecord(profilesRaw)) {
+    return undefined
+  }
+
+  const entries = Object.entries(profilesRaw)
+  if (entries.length === 0) {
+    return undefined
+  }
+
+  const profiles = entries.reduce<Record<string, PersistedWizardProfile>>((acc, [id, value], index) => {
+    acc[id] = normaliseProfile(id, value, `Profil ${index + 1}`)
+    return acc
+  }, {})
+
+  const fallbackActiveId = Object.keys(profiles)[0]!
+  const rawActiveId = storageRecord['activeProfileId']
+  const activeProfileId =
+    typeof rawActiveId === 'string' && profiles[rawActiveId]
+      ? rawActiveId
+      : fallbackActiveId
+
+  return { activeProfileId, profiles }
+}
+
+function migrateLegacyStorage(): PersistedWizardStorage {
+  const state = safeParse<ModuleInput>(window.localStorage.getItem(LEGACY_STATE_KEY)) ?? {}
+  const profileOverrides = safeParse<Partial<WizardProfile>>(window.localStorage.getItem(LEGACY_PROFILE_KEY)) ?? {}
+
+  const entry = createProfileEntry(DEFAULT_PROFILE_ID, DEFAULT_PROFILE_NAME, state)
+  entry.profile = sanitiseWizardProfile(profileOverrides)
+
+  const storage: PersistedWizardStorage = {
+    activeProfileId: entry.id,
+    profiles: { [entry.id]: entry },
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(storage))
+    window.localStorage.removeItem(LEGACY_STATE_KEY)
+    window.localStorage.removeItem(LEGACY_PROFILE_KEY)
+  } catch (error) {
+    console.warn('Kunne ikke migrere wizard-data', error)
+  }
+
+  return storage
+}
+
+function ensureStorage(): PersistedWizardStorage {
+  if (typeof window === 'undefined') {
+    return {
+      activeProfileId: DEFAULT_PROFILE_ID,
+      profiles: { [DEFAULT_PROFILE_ID]: createProfileEntry(DEFAULT_PROFILE_ID, DEFAULT_PROFILE_NAME) },
+    }
+  }
+
+  const parsed = safeParse<unknown>(window.localStorage.getItem(STORAGE_KEY))
+  const storage = normaliseStorage(parsed ?? {})
+
+  if (storage) {
+    return storage
+  }
+
+  if (window.localStorage.getItem(LEGACY_STATE_KEY) || window.localStorage.getItem(LEGACY_PROFILE_KEY)) {
+    return migrateLegacyStorage()
+  }
+
+  const fallbackProfile = createProfileEntry(DEFAULT_PROFILE_ID, DEFAULT_PROFILE_NAME)
+  const fallbackStorage: PersistedWizardStorage = {
+    activeProfileId: fallbackProfile.id,
+    profiles: { [fallbackProfile.id]: fallbackProfile },
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(fallbackStorage))
+  } catch (error) {
+    console.warn('Kunne ikke initialisere wizard-storage', error)
+  }
+
+  return fallbackStorage
+}
+
+export function loadWizardStorage(): PersistedWizardStorage {
+  return ensureStorage()
+}
+
+export function persistWizardStorage(storage: PersistedWizardStorage): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(storage))
+  } catch (error) {
+    console.warn('Kunne ikke gemme wizard-storage', error)
+  }
+}
 
 export function loadWizardState(): ModuleInput {
-  if (typeof window === 'undefined') {
-    return {}
-  }
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    return raw ? (JSON.parse(raw) as ModuleInput) : {}
-  } catch (error) {
-    console.warn('Kunne ikke læse wizard-state', error)
-    return {}
-  }
+  const storage = ensureStorage()
+  const active = storage.profiles[storage.activeProfileId]
+  return active?.state ?? {}
 }
 
 export function persistWizardState(state: ModuleInput): void {
   if (typeof window === 'undefined') {
     return
   }
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-  } catch (error) {
-    console.warn('Kunne ikke gemme wizard-state', error)
+
+  const storage = ensureStorage()
+  const active = storage.profiles[storage.activeProfileId] ?? createProfileEntry(storage.activeProfileId, DEFAULT_PROFILE_NAME)
+  storage.profiles[storage.activeProfileId] = {
+    ...active,
+    state,
+    updatedAt: Date.now(),
   }
+
+  persistWizardStorage(storage)
 }
 
 export function clearWizardState(): void {
@@ -39,32 +234,28 @@ export function clearWizardState(): void {
     return
   }
   window.localStorage.removeItem(STORAGE_KEY)
+  window.localStorage.removeItem(LEGACY_STATE_KEY)
+  window.localStorage.removeItem(LEGACY_PROFILE_KEY)
 }
 
 export function loadWizardProfile(): WizardProfile {
-  if (typeof window === 'undefined') {
-    return createInitialWizardProfile()
-  }
-  try {
-    const raw = window.localStorage.getItem(PROFILE_STORAGE_KEY)
-    if (!raw) {
-      return createInitialWizardProfile()
-    }
-    const parsed = JSON.parse(raw) as Partial<WizardProfile>
-    return { ...createInitialWizardProfile(), ...parsed }
-  } catch (error) {
-    console.warn('Kunne ikke læse wizardProfile', error)
-    return createInitialWizardProfile()
-  }
+  const storage = ensureStorage()
+  const active = storage.profiles[storage.activeProfileId]
+  return active?.profile ?? createInitialWizardProfile()
 }
 
 export function persistWizardProfile(profile: WizardProfile): void {
   if (typeof window === 'undefined') {
     return
   }
-  try {
-    window.localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile))
-  } catch (error) {
-    console.warn('Kunne ikke gemme wizardProfile', error)
+
+  const storage = ensureStorage()
+  const active = storage.profiles[storage.activeProfileId] ?? createProfileEntry(storage.activeProfileId, DEFAULT_PROFILE_NAME)
+  storage.profiles[storage.activeProfileId] = {
+    ...active,
+    profile: { ...createInitialWizardProfile(), ...profile },
+    updatedAt: Date.now(),
   }
+
+  persistWizardStorage(storage)
 }


### PR DESCRIPTION
## Summary
- sanitize persisted wizard profiles to strip invalid values and reuse the helper during legacy migration
- ensure wizard profile duplication deep clones module state to avoid accidental shared references
- cover storage normalisation with a regression test for invalid profile payloads

## Testing
- pnpm --filter @org/web typecheck
- pnpm --filter @org/web test

------
https://chatgpt.com/codex/tasks/task_e_68e39e602510832599a71e0a42a2fc11