### PR TITLE
Add profile switcher and landing CTAs

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,24 +1,86 @@
 /**
  * Landing page der leder brugeren ind i beregningsflowet.
  */
-import Link from 'next/link'
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useMemo } from 'react'
 
 import { PrimaryButton } from '../components/ui/PrimaryButton'
+import { ProfileSwitcher } from '../features/wizard/ProfileSwitcher'
+import { WizardProvider, useWizardContext } from '../features/wizard/useWizard'
 
 export default function HomePage(): JSX.Element {
   return (
+    <WizardProvider>
+      <LandingContent />
+    </WizardProvider>
+  )
+}
+
+function LandingContent(): JSX.Element {
+  const router = useRouter()
+  const { createProfile, switchProfile, profiles, activeProfileId } = useWizardContext()
+
+  const latestProfile = useMemo(() => {
+    const entries = Object.values(profiles)
+    if (entries.length === 0) {
+      return undefined
+    }
+    return entries.reduce((latest, entry) => (entry.updatedAt > latest.updatedAt ? entry : latest), entries[0])
+  }, [profiles])
+
+  const handleCreateProfile = () => {
+    createProfile()
+    router.push('/wizard')
+  }
+
+  const handleOpenLatestProfile = () => {
+    if (!latestProfile) {
+      return
+    }
+    if (latestProfile.id !== activeProfileId) {
+      switchProfile(latestProfile.id)
+    }
+    router.push('/wizard')
+  }
+
+  return (
     <main className="ds-hero">
-      <section className="ds-stack-sm ds-constrain">
-        <p className="ds-text-subtle">Version 4 · Ny UI-oplevelse</p>
-        <h1 className="ds-heading-lg">ESG-rapportering</h1>
-        <p className="ds-text-muted">
-          Start beregning for at udfylde Scope 1- og Scope 2-modulerne, Scope 3-udvidelserne og governance-scoren for D1 –
-          Metode &amp; governance. Alle indtastninger kan redigeres senere i wizard-flowet.
-        </p>
-        <PrimaryButton as={Link} href="/wizard">
-          Start beregning
-        </PrimaryButton>
-      </section>
+      <div className="ds-stack ds-constrain">
+        <section className="ds-stack-sm">
+          <p className="ds-text-subtle">Version 4 · Ny UI-oplevelse</p>
+          <h1 className="ds-heading-lg">ESG-rapportering</h1>
+          <p className="ds-text-muted">
+            Opret eller genåbn en virksomhedsprofil for at afgrænse Scope 1-, Scope 2- og Scope 3-modulerne samt governance
+            flowet. Dine valg gemmes automatisk og kan altid justeres i wizardens venstre kolonne.
+          </p>
+          <div className="ds-cluster">
+            <PrimaryButton onClick={handleCreateProfile}>Ny profil</PrimaryButton>
+            <PrimaryButton onClick={handleOpenLatestProfile} disabled={!latestProfile}>
+              Åbn seneste profil
+            </PrimaryButton>
+          </div>
+          <p className="ds-text-subtle">
+            {latestProfile ? `Seneste profil: ${latestProfile.name}` : 'Ingen profiler oprettet endnu.'}
+          </p>
+        </section>
+
+        <section className="ds-card ds-stack">
+          <h2 className="ds-heading-sm">Sådan fungerer det</h2>
+          <ol className="ds-list">
+            <li>Start med at udfylde virksomhedsprofilen for at aktivere relevante scope-moduler.</li>
+            <li>Gå trin-for-trin gennem modulerne og udfyld datafelter med jeres tal og beskrivelser.</li>
+            <li>Afslut med review-siden, hvor du kan downloade rapporten eller justere profilvalg.</li>
+          </ol>
+        </section>
+
+        <ProfileSwitcher
+          heading="Administrer profiler"
+          description="Få overblik over gemte profiler, dupliker opsætninger eller skift aktiv profil."
+          showCreateButton={false}
+        />
+      </div>
     </main>
   )
 }

--- a/apps/web/features/wizard/ProfileSwitcher.tsx
+++ b/apps/web/features/wizard/ProfileSwitcher.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { PrimaryButton } from '../../components/ui/PrimaryButton'
+import { isModuleRelevant } from '../../src/modules/wizard/profile'
+import { wizardSteps, type WizardScope } from './steps'
+import { useWizardContext } from './useWizard'
+
+const scopeOrder: WizardScope[] = ['Scope 1', 'Scope 2', 'Scope 3', 'Governance']
+
+function formatTimestamp(timestamp: number): string {
+  try {
+    return new Intl.DateTimeFormat('da-DK', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(timestamp))
+  } catch (error) {
+    console.warn('Kunne ikke formatere tidspunkt', error)
+    return new Date(timestamp).toLocaleString()
+  }
+}
+
+type ProfileSwitcherProps = {
+  heading?: string | null
+  description?: string | null
+  showCreateButton?: boolean
+  className?: string
+}
+
+export function ProfileSwitcher({
+  heading = 'Gemte profiler',
+  description = 'Administrer virksomhedsprofiler og skift mellem forskellige scopes.',
+  showCreateButton = true,
+  className,
+}: ProfileSwitcherProps): JSX.Element {
+  const { activeProfileId, profiles, createProfile, switchProfile, renameProfile, duplicateProfile, deleteProfile } =
+    useWizardContext()
+
+  const sortedProfiles = useMemo(
+    () =>
+      Object.values(profiles).sort((a, b) => {
+        if (a.id === activeProfileId) {
+          return -1
+        }
+        if (b.id === activeProfileId) {
+          return 1
+        }
+        if (a.updatedAt === b.updatedAt) {
+          return a.name.localeCompare(b.name)
+        }
+        return b.updatedAt - a.updatedAt
+      }),
+    [activeProfileId, profiles]
+  )
+
+  const handleCreate = () => {
+    createProfile()
+  }
+
+  const handleRename = (profileId: string) => {
+    const current = profiles[profileId]
+    if (!current) {
+      return
+    }
+    const nextName = window.prompt('Nyt profilnavn', current.name)
+    if (nextName) {
+      renameProfile(profileId, nextName)
+    }
+  }
+
+  const handleDuplicate = (profileId: string) => {
+    duplicateProfile(profileId)
+  }
+
+  const handleDelete = (profileId: string) => {
+    const target = profiles[profileId]
+    if (!target) {
+      return
+    }
+    const confirmation = window.confirm(`Slet "${target.name}"? Handling kan ikke fortrydes.`)
+    if (confirmation) {
+      deleteProfile(profileId)
+    }
+  }
+
+  const computeScopeCoverage = (profileId: string) => {
+    const entry = profiles[profileId]
+    if (!entry) {
+      return scopeOrder.map((scope) => ({ scope, isActive: false }))
+    }
+    const coverage = new Set<WizardScope>()
+    for (const step of wizardSteps) {
+      if (isModuleRelevant(entry.profile, step.id)) {
+        coverage.add(step.scope)
+      }
+    }
+    return scopeOrder.map((scope) => ({ scope, isActive: coverage.has(scope) }))
+  }
+
+  return (
+    <section className={['ds-profile-switcher', 'ds-card', 'ds-stack', className].filter(Boolean).join(' ')}>
+      {(heading || description || showCreateButton) && (
+        <header className="ds-profile-switcher__header">
+          <div className="ds-stack-sm">
+            {heading && <h2 className="ds-heading-sm">{heading}</h2>}
+            {description && <p className="ds-text-subtle">{description}</p>}
+          </div>
+          {showCreateButton && (
+            <PrimaryButton className="ds-button--sm" onClick={handleCreate}>
+              Ny profil
+            </PrimaryButton>
+          )}
+        </header>
+      )}
+
+      <ul className="ds-profile-switcher__list" role="list">
+        {sortedProfiles.map((profile) => {
+          const scopes = computeScopeCoverage(profile.id)
+          const lastUpdated = formatTimestamp(profile.updatedAt)
+          const isActive = profile.id === activeProfileId
+
+          return (
+            <li
+              key={profile.id}
+              className="ds-profile-card ds-card ds-card--muted"
+              data-active={isActive ? 'true' : undefined}
+            >
+              <div className="ds-stack-sm">
+                <div className="ds-profile-card__heading">
+                  <h3 className="ds-heading-sm">{profile.name}</h3>
+                  {isActive && <span className="ds-badge" data-active="true">Aktiv</span>}
+                </div>
+                <p className="ds-text-subtle">Senest opdateret {lastUpdated}</p>
+                <div className="ds-cluster">
+                  {scopes.map((entry) => (
+                    <span
+                      key={`${profile.id}-${entry.scope}`}
+                      className="ds-badge"
+                      data-active={entry.isActive ? 'true' : undefined}
+                    >
+                      {entry.scope}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div className="ds-profile-card__actions">
+                <PrimaryButton className="ds-button--sm" onClick={() => switchProfile(profile.id)} disabled={isActive}>
+                  Vælg profil
+                </PrimaryButton>
+                <PrimaryButton
+                  className="ds-button--sm"
+                  variant="ghost"
+                  onClick={() => handleRename(profile.id)}
+                >
+                  Omdøb
+                </PrimaryButton>
+                <PrimaryButton
+                  className="ds-button--sm"
+                  variant="ghost"
+                  onClick={() => handleDuplicate(profile.id)}
+                >
+                  Dupliker
+                </PrimaryButton>
+                <PrimaryButton
+                  className="ds-button--sm"
+                  variant="ghost"
+                  onClick={() => handleDelete(profile.id)}
+                  disabled={sortedProfiles.length === 1}
+                >
+                  Slet
+                </PrimaryButton>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -201,6 +201,13 @@ a {
   color: var(--color-text-muted);
 }
 
+.ds-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  display: grid;
+  gap: var(--space-2);
+}
+
 .ds-text-muted {
   color: var(--color-text-muted);
 }
@@ -396,6 +403,89 @@ a {
   color: var(--color-primary-strong);
   border: 1px solid var(--color-border);
   box-shadow: none;
+}
+
+.ds-shell {
+  display: grid;
+  gap: var(--space-5);
+  align-items: start;
+}
+
+@media (min-width: 960px) {
+  .ds-shell {
+    grid-template-columns: minmax(18rem, 22rem) 1fr;
+  }
+}
+
+.ds-shell__sidebar {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ds-shell__main {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.ds-profile-switcher {
+  gap: var(--space-4);
+}
+
+.ds-profile-switcher__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.ds-profile-switcher__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ds-profile-card {
+  gap: var(--space-3);
+}
+
+.ds-profile-card[data-active='true'] {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+  background: var(--color-surface-strong);
+}
+
+.ds-profile-card__heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ds-profile-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.ds-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: 999px;
+  background: var(--color-surface-muted);
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.ds-badge[data-active='true'] {
+  background: var(--color-primary-weak);
+  color: var(--color-primary-strong);
 }
 
 .ds-button[data-variant='ghost']:hover:not([disabled]) {


### PR DESCRIPTION
## Summary
- add a ProfileSwitcher client component that surfaces scope coverage badges and profile management actions
- expose a wizard context provider and integrate it into the wizard shell together with the new sidebar switcher
- refresh the landing page with guided CTAs, a “Sådan fungerer det” section and supporting styles

## Testing
- pnpm --filter @org/web lint

------
https://chatgpt.com/codex/tasks/task_e_68e3a2cc5de88325b03e21dbe4de204c