### PR TITLE
Enhance wizard styling tokens and lazy step loading

### DIFF
--- a/apps/web/features/wizard/WizardShell.tsx
+++ b/apps/web/features/wizard/WizardShell.tsx
@@ -179,9 +179,9 @@ function WizardShellContent(): JSX.Element {
 
   return (
     <section className="ds-page">
-      <div className="ds-shell ds-shell--wizard">
-        <aside className="ds-shell__sidebar ds-stack">
-          <section className="ds-card ds-stack" aria-label="Status for virksomhedsprofil">
+      <div className="ds-shell ds-shell--wizard ds-layout ds-layout--with-sidebar ds-layout--wizard">
+        <aside className="ds-shell__sidebar ds-stack ds-sidebar ds-sidebar--sticky" data-variant="wizard">
+          <section className="ds-card ds-stack ds-sidebar__section" aria-label="Status for virksomhedsprofil">
             <header className="ds-stack-sm">
               <div className="ds-stack-xs">
                 <p className="ds-text-subtle">Trin 0</p>
@@ -239,6 +239,7 @@ function WizardShellContent(): JSX.Element {
           <ProfileSwitcher
             heading="Profiler"
             description="Skift mellem gemte virksomhedsprofiler."
+            className="ds-sidebar__section"
           />
         </aside>
 

--- a/apps/web/features/wizard/steps/WizardStepSkeleton.tsx
+++ b/apps/web/features/wizard/steps/WizardStepSkeleton.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+export function WizardStepSkeleton(): JSX.Element {
+  return (
+    <div className="ds-card ds-stack" role="status" aria-live="polite" aria-busy="true">
+      <span className="sr-only">Modul indlæses…</span>
+      <div className="ds-stack-sm">
+        <div className="ds-skeleton ds-skeleton--title" />
+        <div className="ds-skeleton ds-skeleton--text" />
+      </div>
+      <div className="ds-stack-sm">
+        <div className="ds-skeleton ds-skeleton--field" />
+        <div className="ds-skeleton ds-skeleton--field" />
+        <div className="ds-cluster">
+          <div className="ds-skeleton ds-skeleton--chip" />
+          <div className="ds-skeleton ds-skeleton--chip" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -16,7 +16,7 @@ function createLazyStep<TModule extends Record<string, unknown>, TExport extends
   loader: () => Promise<TModule>,
   exportName: TExport
 ): WizardStepComponent {
-  return dynamic<WizardStepProps>(
+  const LazyComponent = dynamic<WizardStepProps>(
     async () => {
       const module = await loader()
       const Component = module[exportName]
@@ -27,6 +27,8 @@ function createLazyStep<TModule extends Record<string, unknown>, TExport extends
     },
     { ssr: false, loading: StepLoading }
   )
+
+  return (props) => createElement(LazyComponent, props)
 }
 
 const A1Step = createLazyStep(() => import('./A1'), 'A1Step')

--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -3,39 +3,63 @@
  */
 'use client'
 
+import dynamic from 'next/dynamic'
+import { createElement } from 'react'
+
 import type { ModuleId } from '@org/shared'
-import type { WizardStepComponent } from './StepTemplate'
-import { A1Step } from './A1'
-import { A2Step } from './A2'
-import { A3Step } from './A3'
-import { A4Step } from './A4'
-import { D1Step } from './D1'
-import { B1Step } from './B1'
-import { B2Step } from './B2'
-import { B3Step } from './B3'
-import { B4Step } from './B4'
-import { B5Step } from './B5'
-import { B6Step } from './B6'
-import { B7Step } from './B7'
-import { B8Step } from './B8'
-import { B9Step } from './B9'
-import { B10Step } from './B10'
-import { B11Step } from './B11'
-import { C1Step } from './C1'
-import { C2Step } from './C2'
-import { C3Step } from './C3'
-import { C4Step } from './C4'
-import { C5Step } from './C5'
-import { C6Step } from './C6'
-import { C7Step } from './C7'
-import { C8Step } from './C8'
-import { C9Step } from './C9'
-import { C10Step } from './C10'
-import { C11Step } from './C11'
-import { C12Step } from './C12'
-import { C13Step } from './C13'
-import { C14Step } from './C14'
-import { C15Step } from './C15'
+import type { WizardStepComponent, WizardStepProps } from './StepTemplate'
+import { WizardStepSkeleton } from './WizardStepSkeleton'
+
+const StepLoading = (): JSX.Element => createElement(WizardStepSkeleton)
+
+function createLazyStep<TModule extends Record<string, unknown>, TExport extends keyof TModule>(
+  loader: () => Promise<TModule>,
+  exportName: TExport
+): WizardStepComponent {
+  return dynamic<WizardStepProps>(
+    async () => {
+      const module = await loader()
+      const Component = module[exportName]
+      if (typeof Component !== 'function') {
+        throw new Error(`Wizard-trin "${String(exportName)}" kunne ikke indlæses`)
+      }
+      return Component as WizardStepComponent
+    },
+    { ssr: false, loading: StepLoading }
+  )
+}
+
+const A1Step = createLazyStep(() => import('./A1'), 'A1Step')
+const A2Step = createLazyStep(() => import('./A2'), 'A2Step')
+const A3Step = createLazyStep(() => import('./A3'), 'A3Step')
+const A4Step = createLazyStep(() => import('./A4'), 'A4Step')
+const B1Step = createLazyStep(() => import('./B1'), 'B1Step')
+const B2Step = createLazyStep(() => import('./B2'), 'B2Step')
+const B3Step = createLazyStep(() => import('./B3'), 'B3Step')
+const B4Step = createLazyStep(() => import('./B4'), 'B4Step')
+const B5Step = createLazyStep(() => import('./B5'), 'B5Step')
+const B6Step = createLazyStep(() => import('./B6'), 'B6Step')
+const B7Step = createLazyStep(() => import('./B7'), 'B7Step')
+const B8Step = createLazyStep(() => import('./B8'), 'B8Step')
+const B9Step = createLazyStep(() => import('./B9'), 'B9Step')
+const B10Step = createLazyStep(() => import('./B10'), 'B10Step')
+const B11Step = createLazyStep(() => import('./B11'), 'B11Step')
+const C1Step = createLazyStep(() => import('./C1'), 'C1Step')
+const C2Step = createLazyStep(() => import('./C2'), 'C2Step')
+const C3Step = createLazyStep(() => import('./C3'), 'C3Step')
+const C4Step = createLazyStep(() => import('./C4'), 'C4Step')
+const C5Step = createLazyStep(() => import('./C5'), 'C5Step')
+const C6Step = createLazyStep(() => import('./C6'), 'C6Step')
+const C7Step = createLazyStep(() => import('./C7'), 'C7Step')
+const C8Step = createLazyStep(() => import('./C8'), 'C8Step')
+const C9Step = createLazyStep(() => import('./C9'), 'C9Step')
+const C10Step = createLazyStep(() => import('./C10'), 'C10Step')
+const C11Step = createLazyStep(() => import('./C11'), 'C11Step')
+const C12Step = createLazyStep(() => import('./C12'), 'C12Step')
+const C13Step = createLazyStep(() => import('./C13'), 'C13Step')
+const C14Step = createLazyStep(() => import('./C14'), 'C14Step')
+const C15Step = createLazyStep(() => import('./C15'), 'C15Step')
+const D1Step = createLazyStep(() => import('./D1'), 'D1Step')
 
 export type WizardStep = {
   id: ModuleId

--- a/apps/web/src/modules/wizard/WizardOverview.tsx
+++ b/apps/web/src/modules/wizard/WizardOverview.tsx
@@ -111,9 +111,9 @@ export function WizardOverview({
       </section>
 
       {notRelevantGroups.length > 0 && (
-        <details className="ds-panel ds-collapse" aria-label="Ikke relevante moduler">
-          <summary className="ds-collapse__summary">Ikke relevante</summary>
-          <div className="ds-stack-sm">
+        <details className="ds-foldout" aria-label="Ikke relevante moduler">
+          <summary className="ds-foldout__summary">Ikke relevante</summary>
+          <div className="ds-foldout__content ds-stack-sm">
             {notRelevantGroups.map((group) => (
               <section key={group.scope} className="ds-stack-xs">
                 <p className="ds-text-subtle">{group.scope}</p>
@@ -142,7 +142,7 @@ export function WizardOverview({
                 <span className="ds-pill" data-planned="true">
                   {step.label}
                 </span>
-                <span className="ds-badge" data-variant="planned">
+                <span className="ds-status-badge" data-status="planned">
                   Planlagt
                 </span>
               </li>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -26,6 +26,31 @@
   --font-size-base: 1rem;
   --font-size-lg: 1.25rem;
   --font-size-xl: 1.5rem;
+  --sidebar-width: minmax(18rem, 22rem);
+  --sidebar-width-wide: minmax(20rem, 24rem);
+  --sidebar-gap: var(--space-4);
+  --sidebar-background: transparent;
+  --sidebar-sticky-offset: var(--space-5);
+  --progress-height: 0.625rem;
+  --progress-radius: 999px;
+  --progress-track: var(--color-surface);
+  --progress-border-color: var(--color-border);
+  --progress-indicator: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-strong) 100%);
+  --status-badge-padding-y: 0.25rem;
+  --status-badge-padding-x: 0.5rem;
+  --status-badge-radius: 999px;
+  --status-badge-font-size: var(--font-size-sm);
+  --status-badge-font-weight: 600;
+  --status-badge-background: var(--color-surface-muted);
+  --status-badge-color: var(--color-text-subtle);
+  --status-badge-border: transparent;
+  --foldout-radius: var(--radius-lg);
+  --foldout-border: 1px solid var(--color-border);
+  --foldout-summary-padding: var(--space-4) var(--space-5);
+  --foldout-background: var(--color-surface);
+  --skeleton-base: #dce7e3;
+  --skeleton-highlight: #f2f7f5;
+  --skeleton-radius: var(--radius-sm);
 }
 
 body {
@@ -68,6 +93,48 @@ a {
   gap: var(--space-5);
 }
 
+.ds-layout {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.ds-layout--with-sidebar {
+  align-items: start;
+}
+
+.ds-layout--wizard {
+  gap: var(--space-6);
+}
+
+@media (min-width: 960px) {
+  .ds-layout--with-sidebar {
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  }
+
+  .ds-layout--wizard {
+    grid-template-columns: var(--sidebar-width-wide) minmax(0, 1fr);
+  }
+}
+
+.ds-sidebar {
+  display: grid;
+  gap: var(--sidebar-gap);
+  background: var(--sidebar-background);
+}
+
+.ds-sidebar__section {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 960px) {
+  .ds-sidebar--sticky {
+    position: sticky;
+    top: var(--sidebar-sticky-offset);
+    align-self: start;
+  }
+}
+
 .ds-card {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
@@ -88,12 +155,59 @@ a {
   gap: var(--space-4);
 }
 
-.ds-panel.ds-collapse {
-  padding: 0;
-}
-
 .ds-panel.ds-stack-sm {
   gap: var(--space-3);
+}
+
+:is(.ds-foldout, .ds-panel.ds-collapse) {
+  background: var(--foldout-background);
+  border-radius: var(--foldout-radius);
+  border: var(--foldout-border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  padding: 0;
+  display: grid;
+}
+
+:is(.ds-foldout__summary, .ds-collapse__summary) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--foldout-summary-padding);
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+
+:is(.ds-foldout__summary, .ds-collapse__summary)::-webkit-details-marker {
+  display: none;
+}
+
+:is(.ds-foldout__summary, .ds-collapse__summary)::after {
+  content: '\25BC';
+  font-size: var(--font-size-sm);
+  transition: transform 0.2s ease;
+}
+
+:is(.ds-foldout, .ds-panel.ds-collapse)[open] > :is(.ds-foldout__summary, .ds-collapse__summary) {
+  border-bottom: 1px solid var(--color-border);
+}
+
+:is(.ds-foldout, .ds-panel.ds-collapse)[open]
+  > :is(.ds-foldout__summary, .ds-collapse__summary)::after {
+  transform: rotate(180deg);
+}
+
+.ds-foldout__content {
+  padding: var(--space-4) var(--space-5) var(--space-5);
+  display: grid;
+  gap: var(--space-3);
+  background: var(--foldout-background);
+}
+
+.ds-panel.ds-collapse > .ds-stack-sm {
+  padding: var(--space-4) var(--space-5) var(--space-5);
 }
 
 .ds-accordion {
@@ -114,12 +228,12 @@ a {
   font-weight: 600;
 }
 
-.ds-accordion__summary [aria-hidden] {
-  transition: transform 0.2s ease;
-}
-
 .ds-accordion__summary::-webkit-details-marker {
   display: none;
+}
+
+.ds-accordion__summary [aria-hidden] {
+  transition: transform 0.2s ease;
 }
 
 .ds-accordion[open] > .ds-accordion__summary {
@@ -484,19 +598,17 @@ a {
   display: grid;
   gap: var(--space-5);
   align-items: start;
+  --sidebar-width: minmax(18rem, 22rem);
 }
 
 .ds-shell--wizard {
   gap: var(--space-6);
+  --sidebar-width: var(--sidebar-width-wide);
 }
 
 @media (min-width: 960px) {
   .ds-shell {
-    grid-template-columns: minmax(18rem, 22rem) 1fr;
-  }
-
-  .ds-shell--wizard {
-    grid-template-columns: minmax(20rem, 24rem) 1fr;
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   }
 }
 
@@ -545,17 +657,21 @@ a {
 .ds-progress {
   position: relative;
   width: 100%;
-  height: 0.5rem;
-  border-radius: 999px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  height: var(--progress-height);
+  border-radius: var(--progress-radius);
+  background: var(--progress-track);
+  border: 1px solid var(--progress-border-color);
   overflow: hidden;
+}
+
+.ds-progress[data-size='sm'] {
+  --progress-height: 0.5rem;
 }
 
 .ds-progress__bar {
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-strong) 100%);
+  background: var(--progress-indicator);
   border-radius: inherit;
   transition: width 0.3s ease;
 }
@@ -674,34 +790,70 @@ a {
   justify-content: space-between;
 }
 
+.ds-profile-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .ds-profile-card__actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
 }
 
-.ds-badge {
+:is(.ds-badge, .ds-status-badge) {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  padding: var(--space-1) var(--space-2);
-  border-radius: 999px;
-  background: var(--color-surface-muted);
-  color: var(--color-text-subtle);
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  border: 1px solid transparent;
+  padding: var(--status-badge-padding-y) var(--status-badge-padding-x);
+  border-radius: var(--status-badge-radius);
+  font-size: var(--status-badge-font-size);
+  font-weight: var(--status-badge-font-weight);
+  background: var(--status-badge-background);
+  color: var(--status-badge-color);
+  border: 1px solid var(--status-badge-border);
+  line-height: 1;
 }
 
-.ds-badge[data-active='true'] {
-  background: var(--color-primary-weak);
-  color: var(--color-primary-strong);
+.ds-badge {
+  --status-badge-background: var(--color-surface-muted);
+  --status-badge-color: var(--color-text-subtle);
+  --status-badge-border: transparent;
 }
 
-.ds-badge[data-variant='planned'] {
-  background: var(--color-surface-strong);
-  border-color: var(--color-border-strong);
-  color: var(--color-primary-strong);
+.ds-status-badge {
+  --status-badge-background: var(--color-surface);
+  --status-badge-color: var(--color-text-muted);
+  --status-badge-border: var(--color-border);
+}
+
+:is(.ds-badge, .ds-status-badge)[data-status='active'],
+:is(.ds-badge, .ds-status-badge)[data-active='true'] {
+  --status-badge-background: var(--color-primary-weak);
+  --status-badge-color: var(--color-primary-strong);
+  --status-badge-border: transparent;
+}
+
+:is(.ds-badge, .ds-status-badge)[data-status='inactive'] {
+  --status-badge-background: var(--color-surface-muted);
+  --status-badge-color: var(--color-text-subtle);
+  --status-badge-border: var(--color-border);
+}
+
+:is(.ds-badge, .ds-status-badge)[data-status='planned'],
+:is(.ds-badge, .ds-status-badge)[data-variant='planned'] {
+  --status-badge-background: var(--color-surface-strong);
+  --status-badge-border: var(--color-border-strong);
+  --status-badge-color: var(--color-primary-strong);
+}
+
+:is(.ds-badge, .ds-status-badge)[data-status='timestamp'] {
+  --status-badge-background: var(--color-surface-muted);
+  --status-badge-border: var(--color-border);
+  --status-badge-color: var(--color-text-muted);
+  font-weight: 500;
 }
 
 .ds-alert {
@@ -755,6 +907,49 @@ a {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
+}
+
+.ds-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--skeleton-base);
+  border-radius: var(--skeleton-radius);
+  min-height: 1rem;
+}
+
+.ds-skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, var(--skeleton-highlight), transparent);
+  animation: ds-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.ds-skeleton--title {
+  height: 2rem;
+  max-width: 18rem;
+}
+
+.ds-skeleton--text {
+  height: 1rem;
+  width: 100%;
+}
+
+.ds-skeleton--field {
+  height: 3rem;
+  width: 100%;
+}
+
+.ds-skeleton--chip {
+  height: 1.75rem;
+  width: 7rem;
+}
+
+@keyframes ds-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .ds-code {


### PR DESCRIPTION
## Summary
- extend the design system with sidebar, progress, status badge, foldout, and skeleton utilities and apply them across the wizard experience
- lazy-load wizard step modules with a shared skeleton fallback so only relevant forms are fetched on demand
- surface persisted profile timestamps as “Sidst opdateret” badges within the profile switcher

## Testing
- pnpm --filter @org/web test *(fails: vite cannot resolve @testing-library/react in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c354b6ac8325ad8de263f385955c