### PR TITLE
Align S2–S4 modules with ESRS datapoints

### DIFF
--- a/apps/web/features/wizard/steps/index.ts
+++ b/apps/web/features/wizard/steps/index.ts
@@ -153,15 +153,9 @@ export const wizardSteps: WizardStep[] = [
     status: 'ready'
   },
   { id: 'S1', label: 'S1 – Arbejdsstyrke & headcount', component: S1Step, scope: 'Social', status: 'ready' },
-  { id: 'S2', label: 'S2 – Diversitet og ligestilling', component: S2Step, scope: 'Social', status: 'ready' },
-  { id: 'S3', label: 'S3 – Arbejdsmiljø og hændelser', component: S3Step, scope: 'Social', status: 'ready' },
-  {
-    id: 'S4',
-    label: 'S4 – Due diligence & menneskerettigheder',
-    component: S4Step,
-    scope: 'Social',
-    status: 'ready'
-  },
+  { id: 'S2', label: 'S2 – Værdikædearbejdere', component: S2Step, scope: 'Social', status: 'ready' },
+  { id: 'S3', label: 'S3 – Lokalsamfund og påvirkninger', component: S3Step, scope: 'Social', status: 'ready' },
+  { id: 'S4', label: 'S4 – Forbrugere og slutbrugere', component: S4Step, scope: 'Social', status: 'ready' },
   {
     id: 'G1',
     label: 'G1 – Governance-politikker & targets',

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -8,9 +8,9 @@ Brug oversigten til hurtigt at finde både modulreferencer og runbooks for bereg
 | C10 – Upstream leasede aktiver | [Scope 3 C10 reference](scope-3-c10.md) | [Runbook](../runbooks/module-c10.md) |
 | D1 – Metode & governance       | –                                       | [Runbook](../runbooks/module-d1.md)  |
 | S1 – Arbejdsstyrke & headcount | [Social moduler](social-s1-s4.md#s1-headcount) | [Runbook](../runbooks/module-s1.md) |
-| S2 – Diversitet & ligestilling | [Social moduler](social-s1-s4.md#s2-diversitet) | [Runbook](../runbooks/module-s2.md) |
-| S3 – Arbejdsmiljø & hændelser  | [Social moduler](social-s1-s4.md#s3-haendelser) | [Runbook](../runbooks/module-s3.md) |
-| S4 – Due diligence             | [Social moduler](social-s1-s4.md#s4-due-diligence) | [Runbook](../runbooks/module-s4.md) |
+| S2 – Værdikædearbejdere        | [Social moduler](social-s1-s4.md#s2-vaerdikaede) | [Runbook](../runbooks/module-s2.md) |
+| S3 – Lokalsamfund              | [Social moduler](social-s1-s4.md#s3-lokalsamfund) | [Runbook](../runbooks/module-s3.md) |
+| S4 – Forbrugere & slutbrugere  | [Social moduler](social-s1-s4.md#s4-forbrugere) | [Runbook](../runbooks/module-s4.md) |
 | G1 – Governance-politikker     | [Governance reference](governance-g1.md) | [Runbook](../runbooks/module-g1.md) |
 
 > Se også det samlede [runbook-overblik](../runbooks/overview.md) for anbefalet rækkefølge.

--- a/docs/modules/social-s1-s4.md
+++ b/docs/modules/social-s1-s4.md
@@ -10,26 +10,45 @@ Denne guide beskriver inputfelter og UI-flow for de sociale moduler i wizard-tri
 - Segmentkortene giver felt for segmentnavn, headcount, andel kvinder og kollektiv dækning.
 - Narrative feltet bruges til kontekst og samarbejde med medarbejderrepræsentanter.
 
-<a id="s2-diversitet"></a>
+<a id="esrs-mapping"></a>
 
-## S2 – Diversitet & ligestilling
+## ESRS S2–S4 datapunkter og felter
 
-- `S2Step` understøtter toggle for ligestillingspolitik og datadækning.
-- Hvert niveau har felter for kønsfordeling, løngab og narrative noter.
-- Preview-kortet viser score og warnings i realtid.
+| ESRS datapunkt | Felter i formularen |
+| -------------- | ------------------- |
+| **S2-2.2** – Dækning af risikovurderinger | `valueChainCoveragePercent`, `highRiskSupplierSharePercent` |
+| **S2-2.3** – Sociale audits | `socialAuditsCompletedPercent`, hændelseslisten `incidents` |
+| **S2-5** – Arbejdsvilkår og klagemekanismer | `livingWageCoveragePercent`, `collectiveBargainingCoveragePercent`, `grievancesOpenCount`, `grievanceMechanismForWorkers` |
+| **S3-2** – Konsekvensanalyser | `impactAssessmentsCoveragePercent`, `communitiesIdentifiedCount` |
+| **S3-3** – Negative impacts og klager | `incidents` (lokalsamfund), `grievancesOpenCount` |
+| **S3-5** – Afhjælpning | `remedyNarrative`, remedieringsstatus i `incidents` |
+| **S4-2** – Risikovurdering af produkter | `productsAssessedPercent`, `issues` |
+| **S4-3** – Klagehåndtering | `complaintsResolvedPercent`, `grievanceMechanismInPlace`, `escalationTimeframeDays` |
+| **S4-4** – Datasikkerhedsbrud | `dataBreachesCount`, hændelser med `issueType = dataPrivacy` |
+| **S4-5** – Alvorlige hændelser | `severeIncidentsCount`, `recallsCount`, `issues` |
 
-<a id="s3-haendelser"></a>
+> Øvrige datapunkter om mål og KPI’er (fx S2-6 og S4-6) håndteres via G1/E1-modulerne og er ikke en del af S2–S4-formularerne.
 
-## S3 – Arbejdsmiljø & hændelser
+<a id="s2-vaerdikaede"></a>
 
-- Formularen giver input for arbejdstimer, certificering samt hændelsesliste.
-- Hændelsestyper vælges fra `s3IncidentTypeOptions`; near miss giver kredit.
-- Tekstfeltet bruges til at dokumentere læring og forebyggelse.
+## S2 – Værdikædearbejdere
 
-<a id="s4-due-diligence"></a>
+- `S2Step` indsamler antal arbejdstagere, dækning af risikovurderinger og sociale audits.
+- Incident-tabellen registrerer leverandører, hændelsestyper og remedieringsstatus for ESRS S2-kravene.
+- To narrative felter dækker dialogprogrammer og kompensation/afhjælpning.
 
-## S4 – Due diligence & menneskerettigheder
+<a id="s3-lokalsamfund"></a>
 
-- `S4Step` indsamler klagemekanisme, behandlingstid og processer.
-- Hver proces har felter for område, dækning, vurdering, risikoniveau og remediationsplan.
-- Narrativt felt beskriver governance, samarbejde og næste skridt.
+## S3 – Lokalsamfund og påvirkninger
+
+- Formularen giver tal for identificerede lokalsamfund, dækningsgrad af analyser og antal åbne klager.
+- Hver påvirkning dokumenterer community, type, antal husholdninger og remediering.
+- Narrativerne beskriver engagement (FPIC, dialog) og samarbejde om afhjælpning.
+
+<a id="s4-forbrugere"></a>
+
+## S4 – Forbrugere og slutbrugere
+
+- `S4Step` samler risikovurderingsdækning, klagehåndtering, datasikkerhedsbrud og tilbagekald.
+- Hændelseslisten håndterer produktsikkerhed, data-privacy m.m. med antal berørte brugere og status.
+- Narrativerne fokuserer på støtte til udsatte brugergrupper og proaktivt engagement.

--- a/docs/runbooks/module-s2.md
+++ b/docs/runbooks/module-s2.md
@@ -1,24 +1,25 @@
-# Runbook – S2 diversitet & ligestilling
+# Runbook – S2 værdikædearbejdere
 
-Modulet samler kønsbalancer, løngab og narrative indsatser. Resultatet viser en social score (0-100), hvor paritet, datadækning
-og politikker vægtes.
+Modulet samler ESRS S2 datapunkter om leverandørarbejdere: dækningsgrad af risikovurderinger, sociale audits, klagemekanismer og registrerede hændelser. Resultatet er en social score (0-100) med fokus på dækning, arbejdstagerbeskyttelse og hændelsesstyring.
 
 ## Inputfelter
 
-- **Datadækning (%)** – andel af arbejdsstyrken med registreret diversitetsdata.
-- **Formel ligestillingspolitik** – ja/nej/ikke angivet.
-- **Kønsfordeling pr. niveau** – liste over niveauer med procentfordeling, løngab og optional narrativ.
-- **Narrativ beskrivelse** – tekst om initiativer, pipeline og barrierer.
+- **Arbejdstagere i værdikæden** og **udsatte arbejdstagere** – bruges til at dimensionere hændelser og warnings.
+- **Risikodækning (%)** og **andel højrisiko-leverandører (%)** – dokumenterer ESRS S2-2.2.
+- **Leve-/mindsteløn (%)** og **kollektive aftaler (%)** – afdækker arbejdstagerrettigheder (S2-5).
+- **Sociale audits (%)**, **åbne klager** og **klagemekanisme** – viser opfølgning og remediering (S2-2.3 og S2-5).
+- **Hændelseslisten** – registrerer leverandør/site, hændelsestype, antal berørte, alvorlighed og remedieringsstatus.
+- **Narrativer** – dialog/kapacitetsopbygning samt kompensation og opfølgning.
 
 ## Beregningsoverblik
 
-1. Paritetsscore (60 %) beregnes som gennemsnit af niveauers afvigelse fra 50/50 (nul score ved ±20 procentpoint).
-2. Datadækning (20 %) normaliseres 0-100 %.
-3. Politikscore (20 %) belønner formaliseret ligestillingspolitik og giver baseline-score for "ikke angivet".
-4. Warnings udsendes ved lave datadækninger, store afvigelser (>10 procentpoint) eller løngab over 5 %.
+1. Dækningsscore (35 %) bygger på `valueChainCoveragePercent` (warning under 70 %).
+2. Beskyttelsesscore (25 %) er gennemsnit af `livingWageCoveragePercent` og `collectiveBargainingCoveragePercent`.
+3. Audit- og klagemekanisme (30 %) kombinerer `socialAuditsCompletedPercent`, `grievanceMechanismForWorkers` og åbne klager.
+4. Hændelser reducerer scoren ud fra alvorlighed, antal berørte og remediering. Højrisiko uden afsluttet remediering udløser warnings.
 
 ## QA og test
 
-- Unit-testen `runS2` i `runModule.spec.ts` dækker et scenarie med høj score og kontrollerer warnings.
-- `S2Step` i webappen understøtter tabelformular med flere niveauer, pay gap og narrativer.
-- Schema-validering ligger i `s2InputSchema` og JSON schema, så nye felter skal opdateres begge steder.
+- Unit-testen `runS2` i `runModule.spec.ts` dækker scenario med flere hændelser og kontrollerer trace/warnings.
+- UI (`S2Step`) understøtter alle datapunkter samt incident-tabellen og narrativer.
+- Validering findes i `s2InputSchema` og `esg-input-schema.json`; husk at opdatere begge ved schemaændringer.

--- a/docs/runbooks/module-s3.md
+++ b/docs/runbooks/module-s3.md
@@ -1,23 +1,25 @@
-# Runbook – S3 arbejdsmiljø & hændelser
+# Runbook – S3 lokalsamfund & påvirkninger
 
-Modulet aggregerer arbejdsmiljøhændelser, arbejdstimer og certificering for at producere en social sikkerhedsscore (0-100).
+Modulet dækker ESRS S3 datapunkter om berørte lokalsamfund: konsekvensanalyser, klager, registrerede impacts og afhjælpning. Resultatet er en social score (0-100) baseret på dækning, højrisikoandel, dialog og hændelsesstyring.
 
 ## Inputfelter
 
-- **Total arbejdstimer** – arbejdstimer i rapporteringsåret.
-- **Arbejdsmiljøcertificering** – ISO 45001 eller tilsvarende.
-- **Hændelsesliste** – type (fatalitet, lost time, recordable, near miss), antal, rate pr. million timer og root cause status.
-- **Narrativ opfølgning** – tekst om læring og forebyggelse.
+- **Identificerede lokalsamfund** og **dækningsgrad af analyser (%)** – svarer til S3-2.
+- **Højrisiko-lokalsamfund (%)** – bruges til warnings når andelen er høj.
+- **Åbne klager** – dokumenterer S3-3 om klagemekanismer.
+- **Påvirkningsliste** – community, geografi, impact-type, husholdninger, alvorlighed, remediering og beskrivelse.
+- **Narrativer** – engagement/FPIC og afhjælpning/samarbejde.
 
 ## Beregningsoverblik
 
-1. Hver hændelse vægtes: fatalitet (45), lost time (18), recordable (8). Near miss giver -2 (incitament for rapportering).
-2. Total penalty normaliseres pr. million timer (baseline 3 hændelser/mio. timer) og konverteres til score 0-100.
-3. ISO 45001 giver +10 bonuspoint, uden at overstige 100.
-4. Warnings udsendes ved fataliteter, manglende rodårsagslukning eller høje hændelsesrater.
+1. Konsekvensanalyser (35 %) normaliseres ud fra `impactAssessmentsCoveragePercent` med warning under 60 %.
+2. Højrisikoandel (20 %) omregnes til score (lav andel giver høj score).
+3. Klagehåndtering (15 %) beregnes ud fra antal åbne klager.
+4. Engagement (15 %) vurderes via narrativets længde og udførlighed.
+5. Hændelser reducerer scoren baseret på alvorlighed, husholdninger og remediering. Uafsluttede højrisiko-impacts giver warnings.
 
 ## QA og test
 
-- Unit-testen `runS3` i `runModule.spec.ts` dækker certificeret scenarie og kontrollerer trace/warnings.
-- `S3Step` UI stiller input for både kvantitative tal og narrativer.
-- Nye hændelsestyper kræver opdatering af `s3IncidentTypeOptions`, schema og run-modulet.
+- Unit-testen `runS3` i `runModule.spec.ts` dækker scenario med flere impacts og verificerer warnings/trace.
+- UI (`S3Step`) understøtter alle felter samt tabellen for lokalsamfund.
+- Opdater både `s3InputSchema` og JSON schema ved nye felter.

--- a/docs/runbooks/module-s4.md
+++ b/docs/runbooks/module-s4.md
@@ -1,24 +1,24 @@
-# Runbook – S4 due diligence & menneskerettigheder
+# Runbook – S4 forbrugere & slutbrugere
 
-Modulet hjælper rådgivere med at dokumentere due diligence-processer, klagemekanismer og narrativer. Outputtet er en social
-score (0-100) med fokus på dækning, risikoniveau og remediationsplaner.
+Modulet dækker ESRS S4 datapunkter om produkter og slutbrugere: risikovurdering, klagehåndtering, datasikkerhed og alvorlige hændelser. Resultatet er en social score (0-100) baseret på dækning, klageprocesser og hændelsesstyring.
 
 ## Inputfelter
 
-- **Klagemekanisme** – ja/nej/ikke angivet.
-- **Escalationstid (dage)** – behandlingstid for klager.
-- **Procesliste** – område, dækning (%), seneste vurdering, risikoniveau, remediationsplan.
-- **Narrativ due diligence** – tekst om governance, samarbejde og opfølgning.
+- **Produkter med risikovurdering (%)** – S4-2.
+- **Klager løst inden for SLA (%)** og **klagemekanisme** – S4-3.
+- **Datasikkerhedsbrud**, **alvorlige hændelser** og **produkt-/service-recalls** – S4-4 og S4-5.
+- **Hændelsesliste** – produkt/service, marked, hændelsestype, berørte brugere, alvorlighed og remediering.
+- **Narrativer** – støtte til udsatte brugergrupper og engagement/uddannelse.
 
 ## Beregningsoverblik
 
-1. Dækning vægter 60 % (gennemsnit af coverage%).
-2. Risiko vægter 20 %. Højrisiko uden plan udløser fuldt fradrag, med plan halvt fradrag; medium risiko giver mindre fradrag.
-3. Klagemekanisme vægter 20 % – bonus for etableret mekanisme, baselinescore for "ikke angivet".
-4. Warnings udsendes ved manglende processer, højrisiko uden plan samt manglende narrativer.
+1. Risikovurdering (30 %) via `productsAssessedPercent`.
+2. Klagehåndtering (20 %) via `complaintsResolvedPercent` kombineret med mekanisme og behandlingstid.
+3. Datasikkerhed (15 %) reduceres ved `dataBreachesCount`.
+4. Hændelser reducerer scoren baseret på alvorlighed, antal brugere og remediering. Ekstra penalty for `severeIncidentsCount` og `recallsCount`.
 
 ## QA og test
 
-- Unit-testen `runS4` i `runModule.spec.ts` verificerer score og warnings for processer med og uden remediation.
-- `S4Step` UI understøtter både kvantitative felter og narrative tekstfelter.
-- Schema og JSON-schema (`s4InputSchema`) skal udvides ved nye felter.
+- Unit-testen `runS4` i `runModule.spec.ts` dækker scenario med flere hændelser og kontrollerer warnings.
+- UI (`S4Step`) understøtter talfelter, hændelsesliste og narrativer.
+- Opdater `s4InputSchema` og JSON schema ved nye datapunkter.

--- a/docs/runbooks/overview.md
+++ b/docs/runbooks/overview.md
@@ -9,9 +9,9 @@ Denne oversigt samler alle modulrunbooks og den anbefalede gennemførelsesrække
 | 3          | E1 – Klimamål og handlinger    | Saml ESRS E1-mål, ansvarlige og actionplaner til intensiteter og mix. | [module-e1targets.md](module-e1targets.md) |
 | 4          | D1 – Metode & governance       | Dokumentér governance-metoder og strategi for compliance-score.       | [module-d1.md](module-d1.md)     |
 | 5          | S1 – Arbejdsstyrke & headcount | Registrér headcount, segmenter og faglig repræsentation for social score. | [module-s1.md](module-s1.md)     |
-| 6          | S2 – Diversitet & ligestilling | Kortlæg kønsfordeling, løngab og initiativer på tværs af niveauer.    | [module-s2.md](module-s2.md)     |
-| 7          | S3 – Arbejdsmiljø & hændelser  | Indtast hændelser, arbejdstimer og certificering for sikkerhedsscore. | [module-s3.md](module-s3.md)     |
-| 8          | S4 – Due diligence             | Dokumentér processer, risikoniveauer og klagemekanismer.              | [module-s4.md](module-s4.md)     |
+| 6          | S2 – Værdikædearbejdere        | Registrér risikovurdering, sociale audits og hændelser i leverandørleddet. | [module-s2.md](module-s2.md)     |
+| 7          | S3 – Lokalsamfund              | Dokumentér impacts, klager og afhjælpning for berørte lokalsamfund.   | [module-s3.md](module-s3.md)     |
+| 8          | S4 – Forbrugere & slutbrugere  | Saml produkt-risikovurdering, klageprocesser og alvorlige hændelser.  | [module-s4.md](module-s4.md)     |
 | 9          | G1 – Governance-politikker     | Saml politikker, targets og bestyrelsestilsyn for governance-score.   | [module-g1.md](module-g1.md)     |
 
 > Brug oversigten som indgang til både UI-flow, beregningslogik og QA-krav for hvert modul.

--- a/packages/shared/calculations/__tests__/runModule.spec.ts
+++ b/packages/shared/calculations/__tests__/runModule.spec.ts
@@ -304,107 +304,139 @@ describe('runS1', () => {
 })
 
 describe('runS2', () => {
-  it('beregner ligestillingsscore med højt datagrundlag', () => {
+  it('beregner social score for værdikædearbejdere og giver relevante warnings', () => {
     const input: ModuleInput = {
       S2: {
-        equalityPolicyInPlace: true,
-        dataCoveragePercent: 95,
-        genderBalance: [
+        valueChainWorkersCount: 2400,
+        workersAtRiskCount: 180,
+        valueChainCoveragePercent: 85,
+        highRiskSupplierSharePercent: 22,
+        livingWageCoveragePercent: 88,
+        collectiveBargainingCoveragePercent: 60,
+        socialAuditsCompletedPercent: 92,
+        grievancesOpenCount: 1,
+        grievanceMechanismForWorkers: true,
+        incidents: [
           {
-            level: 'Bestyrelse',
-            femalePercent: 48,
-            malePercent: 52,
-            otherPercent: 0,
-            payGapPercent: 2,
-            targetNarrative: null
+            supplier: 'Alpha Textiles',
+            country: 'Bangladesh',
+            issueType: 'wagesAndBenefits',
+            workersAffected: 60,
+            severityLevel: 'medium',
+            remediationStatus: 'inProgress',
+            description: 'Løn ligger under aftalt minimum – forbedringsplan igangsat.'
           },
           {
-            level: 'Ledelse',
-            femalePercent: 55,
-            malePercent: 45,
-            otherPercent: 0,
-            payGapPercent: -1,
-            targetNarrative: null
+            supplier: 'Omega Plast',
+            country: 'Malaysia',
+            issueType: 'healthAndSafety',
+            workersAffected: 20,
+            severityLevel: 'low',
+            remediationStatus: 'completed',
+            description: null
           }
         ],
-        inclusionInitiativesNarrative: 'Mentorprogram og målrettet pipeline-udvikling.'
+        socialDialogueNarrative:
+          'Leverandørprogram med kvartalsvise dialogmøder, træning i arbejdsmiljø og co-funding af fagforeningsarbejde.',
+        remediationNarrative:
+          'Kompensation til påvirkede syersker samt auditopfølgning med fokus på lønjusteringer og forbedret tilsyn.'
       }
     }
 
     const result = runS2(input)
 
-    expect(result.value).toBeCloseTo(88.5)
-    expect(result.warnings).toHaveLength(0)
-    expect(result.trace).toContain('dataCoveragePercent=95')
+    expect(result.value).toBeGreaterThan(70)
+    expect(result.trace).toContain('valueChainCoveragePercent=85')
+    expect(result.warnings).toContain('1 klager fra leverandørarbejdere er åbne. Følg op og luk dem for at undgå ESRS S2 advarsler.')
   })
 })
 
 describe('runS3', () => {
-  it('giver høj score ved lav hændelsesrate og certificering', () => {
+  it('prioriterer konsekvensanalyser og håndtering af lokalsamfundsimpacts', () => {
     const input: ModuleInput = {
       S3: {
-        totalHoursWorked: 2_000_000,
-        safetyCertification: true,
+        communitiesIdentifiedCount: 5,
+        impactAssessmentsCoveragePercent: 80,
+        highRiskCommunitySharePercent: 25,
+        grievancesOpenCount: 0,
         incidents: [
           {
-            incidentType: 'lostTime',
-            count: 1,
-            ratePerMillionHours: 0.5,
-            description: null,
-            rootCauseClosed: true
+            community: 'Fjordbyen',
+            geography: 'Norge',
+            impactType: 'environmentalDamage',
+            householdsAffected: 40,
+            severityLevel: 'medium',
+            remediationStatus: 'inProgress',
+            description: 'Udslip fra byggeplads påvirker fiskeri – midlertidig kompensation igangsat.'
           },
           {
-            incidentType: 'nearMiss',
-            count: 4,
-            ratePerMillionHours: null,
-            description: 'Indrapporteret af værkstedet',
-            rootCauseClosed: true
+            community: 'Skovlandsbyen',
+            geography: 'Sverige',
+            impactType: 'landRights',
+            householdsAffected: 12,
+            severityLevel: 'low',
+            remediationStatus: 'completed',
+            description: 'Aftale om adgangsveje indgået med lokalsamfundet.'
           }
         ],
-        safetyNarrative: 'Fokus på proaktive observationer og lukning af rodårsager.'
+        engagementNarrative:
+          'Årlige FPIC-dialoger, borgerpaneler og samarbejde med lokale NGO’er for at sikre inklusion.',
+        remedyNarrative:
+          'Kompensationsfonde samt investering i infrastruktur projekter for de mest påvirkede områder.'
       }
     }
 
     const result = runS3(input)
 
-    expect(result.value).toBeCloseTo(68.3, 1)
-    expect(result.trace).toContain('hoursWorked=2000000')
-    expect(result.assumptions).toContain('ISO 45001 eller tilsvarende certificering udløser +10 bonuspoint.')
+    expect(result.value).toBeGreaterThan(60)
+    expect(result.trace).toContain('impactAssessmentsCoveragePercent=80')
+    expect(result.warnings).not.toContain('Ingen påvirkninger registreret endnu.')
   })
 })
 
 describe('runS4', () => {
-  it('kombinerer coverage, risiko og grievance-mekanismer', () => {
+  it('kombinerer risikovurdering, klagehåndtering og hændelsesstyring', () => {
     const input: ModuleInput = {
       S4: {
+        productsAssessedPercent: 70,
+        complaintsResolvedPercent: 85,
+        dataBreachesCount: 1,
+        severeIncidentsCount: 1,
+        recallsCount: 0,
         grievanceMechanismInPlace: true,
-        escalationTimeframeDays: 21,
-        dueDiligenceNarrative:
-          'Leverandør-screening opdateres årligt med fokus på menneskerettigheder og whistleblower-kanaler.',
-        processes: [
+        escalationTimeframeDays: 20,
+        issues: [
           {
-            area: 'Leverandører',
-            coveragePercent: 80,
-            lastAssessmentDate: '2024-01-15',
-            severityLevel: 'high',
-            remediationPlan: 'Auditprogram og leverandørtræning'
+            productOrService: 'SmartHome Hub',
+            market: 'EU',
+            issueType: 'productSafety',
+            usersAffected: 120,
+            severityLevel: 'medium',
+            remediationStatus: 'completed',
+            description: 'Firmwareopdatering reducerer risiko for overophedning.'
           },
           {
-            area: 'Egnet personale',
-            coveragePercent: 60,
-            lastAssessmentDate: null,
-            severityLevel: 'medium',
-            remediationPlan: null
+            productOrService: 'Cloud Backup',
+            market: 'Global',
+            issueType: 'dataPrivacy',
+            usersAffected: 50,
+            severityLevel: 'high',
+            remediationStatus: 'inProgress',
+            description: 'Dataeksponering under undersøgelse, midlertidige kontroller implementeret.'
           }
-        ]
+        ],
+        vulnerableUsersNarrative:
+          'Udvikler forenklet supportlinje og subsidier til seniorer samt handicapvenlige grænseflader.',
+        consumerEngagementNarrative:
+          'Kvartalsvise webinarer og samarbejde med forbrugerorganisationer om klare sikkerhedsanbefalinger.'
       }
     }
 
     const result = runS4(input)
 
-    expect(result.value).toBe(70)
-    expect(result.trace).toContain('process[0]=Leverandører|coverage=80|severity=high')
-    expect(result.warnings).toContain('Højrisiko-området "Egnet personale" mangler remediationsplan.')
+    expect(result.value).toBeGreaterThan(50)
+    expect(result.trace).toContain('productsAssessedPercent=70')
+    expect(result.warnings).toContain('1 alvorlige hændelser rapporteret – offentliggør detaljer og kompensation.')
   })
 })
 

--- a/packages/shared/calculations/factors.ts
+++ b/packages/shared/calculations/factors.ts
@@ -361,33 +361,65 @@ export const factors = {
   s2: {
     unit: 'social score',
     resultPrecision: 1,
-    parityWeight: 0.6,
-    coverageWeight: 0.2,
-    policyWeight: 0.2,
-    fullParityPercent: 50,
-    severeGapPercent: 20,
-    narrativeLimit: 2000
+    coverageWeight: 0.35,
+    protectionWeight: 0.25,
+    auditWeight: 0.15,
+    grievanceWeight: 0.15,
+    incidentWeight: 0.1,
+    severityWeights: {
+      high: 1,
+      medium: 0.6,
+      low: 0.3
+    } as const,
+    resolvedMitigation: 0.4,
+    inProgressMitigation: 0.7,
+    defaultIncidentScale: 0.05,
+    openGrievancePenaltyPerCase: 0.03,
+    mechanismUnknownScore: 0.5,
+    coverageWarningThresholdPercent: 70,
+    livingWageWarningThresholdPercent: 60,
+    bargainingWarningThresholdPercent: 50,
+    auditWarningThresholdPercent: 60
   },
   s3: {
     unit: 'social score',
     resultPrecision: 1,
-    fatalityPenalty: 45,
-    lostTimePenalty: 18,
-    recordablePenalty: 8,
-    nearMissCredit: 2,
-    baselineHoursDivisor: 1_000_000,
-    baselineTargetRate: 3,
-    ratePenaltyMultiplier: 12,
-    certificationBonus: 10
+    assessmentWeight: 0.35,
+    highRiskWeight: 0.2,
+    grievanceWeight: 0.15,
+    engagementWeight: 0.15,
+    incidentWeight: 0.15,
+    severityWeights: {
+      high: 1.1,
+      medium: 0.6,
+      low: 0.3
+    } as const,
+    resolvedMitigation: 0.4,
+    inProgressMitigation: 0.7,
+    defaultIncidentScale: 0.04,
+    openGrievancePenaltyPerCase: 0.04,
+    assessmentWarningThresholdPercent: 60,
+    highRiskWarningThresholdPercent: 30
   },
   s4: {
     unit: 'social score',
     resultPrecision: 1,
-    coverageWeight: 0.6,
-    severityWeight: 0.2,
-    grievanceWeight: 0.2,
-    highRiskPenalty: 0.6,
-    mediumRiskPenalty: 0.3
+    coverageWeight: 0.3,
+    complaintResolutionWeight: 0.2,
+    mechanismWeight: 0.1,
+    incidentWeight: 0.25,
+    dataProtectionWeight: 0.15,
+    severityWeights: {
+      high: 1,
+      medium: 0.5,
+      low: 0.2
+    } as const,
+    resolvedMitigation: 0.4,
+    inProgressMitigation: 0.7,
+    defaultIncidentScale: 0.03,
+    complaintResolutionWarningPercent: 70,
+    escalationWarningDays: 30,
+    productsCoverageWarningPercent: 60
   },
   g1: {
     unit: 'governance score',

--- a/packages/shared/calculations/modules/runS2.ts
+++ b/packages/shared/calculations/modules/runS2.ts
@@ -1,98 +1,69 @@
 /**
- * Beregning for modul S2 – diversitet, ligestilling og inklusion.
+ * Beregning for modul S2 – værdikædearbejdere og arbejdsforhold.
  */
 import type { ModuleInput, ModuleResult, S2Input } from '../../types'
 import { factors } from '../factors'
 
 const { s2 } = factors
 
-type NormalisedRow = {
+type IncidentRow = NonNullable<S2Input['incidents']>[number]
+
+type NormalisedIncident = {
   index: number
-  level: string
-  femalePercent: number | null
-  malePercent: number | null
-  otherPercent: number | null
-  payGapPercent: number | null
-  narrative: string | null
+  supplier: string | null
+  country: string | null
+  issueType: string | null
+  workersAffected: number | null
+  severityLevel: NormalisedSeverity
+  remediationStatus: NormalisedStatus
+  description: string | null
 }
+
+type NormalisedSeverity = NonNullable<IncidentRow['severityLevel']> | null
+type NormalisedStatus = NonNullable<IncidentRow['remediationStatus']> | null
+
+type PercentLike = number | null | undefined
 
 export function runS2(input: ModuleInput): ModuleResult {
   const raw = (input.S2 ?? null) as S2Input | null
-  const rows = normaliseRows(raw?.genderBalance)
+  const incidents = normaliseIncidents(raw?.incidents)
   const trace: string[] = []
   const warnings: string[] = []
   const assumptions = [
-    'Scoren vægter ligestilling (60 %), datadækning (20 %) og politik/indsats (20 %).',
-    'Kønsbalancen vurderes mod paritet (50/50) med fuld score ved ±5 procentpoint og nul score ved ±20 procentpoint.'
+    'Scoren vægter værdikædedækning (35 %), arbejdstagerbeskyttelse (25 %), audits (15 %) og klagemekanismer (15 %).',
+    'Alvorlige hændelser reducerer score afhængigt af antal berørte arbejdstagere og status på remediering.'
   ]
 
-  const coveragePercent = resolveCoverage(raw, rows)
-  const policyScore = raw?.equalityPolicyInPlace === true ? 1 : raw?.equalityPolicyInPlace === false ? 0 : 0.2
+  const coverageScore = resolveCoverageScore(raw, trace, warnings)
+  const protectionScore = resolveProtectionScore(raw, warnings, trace)
+  const auditScore = resolveAuditScore(raw, warnings, trace)
+  const mechanismScore = resolveMechanismScore(raw, warnings)
+  const incidentPenalty = computeIncidentPenalty(raw, incidents, trace, warnings)
+  const grievancePenalty = computeGrievancePenalty(raw, trace, warnings)
 
-  if (coveragePercent == null) {
-    warnings.push('Datadækning for diversitet er ikke angivet. Udfyld dækning eller flere rækker.')
-  } else {
-    trace.push(`dataCoveragePercent=${coveragePercent}`)
-    if (coveragePercent < 80) {
-      warnings.push(`Diversitetsdata dækker kun ${coveragePercent}% af arbejdsstyrken – CSRD kræver fuld repræsentation.`)
+  const baseScore =
+    s2.coverageWeight * coverageScore +
+    s2.protectionWeight * protectionScore +
+    s2.auditWeight * auditScore +
+    s2.grievanceWeight * mechanismScore
+
+  const penalty = s2.incidentWeight * Math.min(1, incidentPenalty + grievancePenalty)
+  const value = Number((Math.max(0, Math.min(1, baseScore - penalty)) * 100).toFixed(s2.resultPrecision))
+
+  if (incidents.length === 0) {
+    trace.push('incidents=0')
+    if ((raw?.workersAtRiskCount ?? 0) > 0) {
+      warnings.push('Ingen hændelser registreret, men der er angivet risikofyldte arbejdstagere. Verificér screeningen.')
     }
   }
 
-  if (raw?.equalityPolicyInPlace == null) {
-    warnings.push('Angiv om virksomheden har en ligestillingspolitik – feltet er påkrævet i ESRS S1/S4.')
-  } else if (raw.equalityPolicyInPlace === false) {
-    warnings.push('Ingen ligestillingspolitik markeret. Overvej at etablere politik og targets.')
+  if (raw?.socialDialogueNarrative == null || raw.socialDialogueNarrative.trim().length < 40) {
+    warnings.push('Tilføj narrativ om dialog og træning af leverandørarbejdere (ESRS S2 §21-23).')
   }
 
-  const parityScores: number[] = []
-
-  rows.forEach((row) => {
-    const gap = computeParityGap(row)
-    const rowScore = gap == null ? null : Math.max(0, 1 - gap / s2.severeGapPercent)
-    if (rowScore != null) {
-      parityScores.push(rowScore)
-    }
-
-    if (gap != null) {
-      trace.push(`parityGap[${row.index}]=${gap.toFixed(1)}`)
-      if (gap >= s2.severeGapPercent) {
-        warnings.push(
-          `Kønsbalancen for "${row.level}" afviger ${gap.toFixed(1)} procentpoint fra paritet. Udarbejd plan for forbedring.`
-        )
-      }
-      if (gap >= 10 && raw?.inclusionInitiativesNarrative == null) {
-        warnings.push(
-          `Tilføj narrative indsatser i S2 for "${row.level}" – større afvigelser kræver dokumenterede initiativer.`
-        )
-      }
-    }
-
-    if (row.payGapPercent != null) {
-      trace.push(`payGap[${row.index}]=${row.payGapPercent}`)
-      if (Math.abs(row.payGapPercent) > 5) {
-        warnings.push(
-          `Løngabet for "${row.level}" er ${row.payGapPercent}% – dokumentér plan for at lukke gap'et.`
-        )
-      }
-    }
-
-    trace.push(
-      `row[${row.index}]=${encodeTrace(row.level)}|female=${row.femalePercent ?? 'null'}|male=${
-        row.malePercent ?? 'null'
-      }|other=${row.otherPercent ?? 'null'}`
-    )
-  })
-
-  if (rows.length === 0) {
-    warnings.push('Ingen diversitetsrækker registreret. Tilføj mindst én ledelses-/medarbejdergruppe.')
-    trace.push('rows=0')
+  if (raw?.remediationNarrative == null || raw.remediationNarrative.trim().length < 40) {
+    warnings.push('Tilføj narrativ om afhjælpning og kompensation til leverandørarbejdere (ESRS S2 §28).')
   }
-
-  const parityScore = parityScores.length === 0 ? 0 : parityScores.reduce((sum, value) => sum + value, 0) / parityScores.length
-  const coverageScore = normalisePercent(coveragePercent)
-
-  const totalScore = s2.parityWeight * parityScore + s2.coverageWeight * coverageScore + s2.policyWeight * policyScore
-  const value = Number((Math.max(0, Math.min(totalScore, 1)) * 100).toFixed(s2.resultPrecision))
 
   return {
     value,
@@ -103,80 +74,227 @@ export function runS2(input: ModuleInput): ModuleResult {
   }
 }
 
-function normaliseRows(rows: S2Input['genderBalance']): NormalisedRow[] {
+function resolveCoverageScore(raw: S2Input | null, trace: string[], warnings: string[]): number {
+  const percent = clampPercent(raw?.valueChainCoveragePercent)
+  if (percent == null) {
+    warnings.push('Angiv værdikædedækning i procent – feltet er nødvendigt for ESRS S2 datapunkt S2-2.2.')
+    return 0
+  }
+
+  trace.push(`valueChainCoveragePercent=${percent}`)
+  if (percent < s2.coverageWarningThresholdPercent) {
+    warnings.push(
+      `Værdikædedækningen er ${percent}% – gennemfør flere risikovurderinger for højere compliance (mål ≥ ${s2.coverageWarningThresholdPercent}%).`
+    )
+  }
+  return normalisePercent(percent)
+}
+
+function resolveProtectionScore(raw: S2Input | null, warnings: string[], trace: string[]): number {
+  const livingWage = clampPercent(raw?.livingWageCoveragePercent)
+  const bargaining = clampPercent(raw?.collectiveBargainingCoveragePercent)
+  const values: number[] = []
+
+  if (livingWage != null) {
+    trace.push(`livingWageCoveragePercent=${livingWage}`)
+    if (livingWage < s2.livingWageWarningThresholdPercent) {
+      warnings.push(
+        `Kun ${livingWage}% af værdikædearbejderne er dækket af leve-/mindsteløn. Forbedr lønkrav i kontrakter (ESRS S2 datapunkt S2-5).`
+      )
+    }
+    values.push(normalisePercent(livingWage))
+  } else {
+    warnings.push('Angiv andelen af værdikædearbejdere med leve- eller mindsteløn.')
+  }
+
+  if (bargaining != null) {
+    trace.push(`collectiveBargainingCoveragePercent=${bargaining}`)
+    if (bargaining < s2.bargainingWarningThresholdPercent) {
+      warnings.push(
+        `Andelen med kollektive aftaler eller repræsentation er ${bargaining}% – styrk organisationsfriheden (ESRS S2 datapunkt S2-5).`
+      )
+    }
+    values.push(normalisePercent(bargaining))
+  } else {
+    warnings.push('Angiv dækning af kollektive aftaler og organisationsfrihed for leverandørarbejdere.')
+  }
+
+  if (values.length === 0) {
+    return 0
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function resolveAuditScore(raw: S2Input | null, warnings: string[], trace: string[]): number {
+  const percent = clampPercent(raw?.socialAuditsCompletedPercent)
+  if (percent == null) {
+    warnings.push('Angiv hvor stor en andel af planlagte sociale audits der er gennemført (ESRS S2 datapunkt S2-2.3).')
+    return 0
+  }
+
+  trace.push(`socialAuditsCompletedPercent=${percent}`)
+  if (percent < s2.auditWarningThresholdPercent) {
+    warnings.push(`Kun ${percent}% af sociale audits er gennemført. Øg auditfrekvensen for højrisikoleverandører.`)
+  }
+
+  return normalisePercent(percent)
+}
+
+function resolveMechanismScore(raw: S2Input | null, warnings: string[]): number {
+  if (raw?.grievanceMechanismForWorkers == null) {
+    warnings.push('Angiv om leverandørarbejdere har adgang til klagemekanismer (ESRS S2 datapunkt S2-5).')
+    return s2.mechanismUnknownScore
+  }
+
+  if (raw.grievanceMechanismForWorkers === false) {
+    warnings.push('Ingen klagemekanisme for leverandørarbejdere. Etabler hotline eller samarbejde med fagforeninger.')
+    return 0
+  }
+
+  return 1
+}
+
+function computeIncidentPenalty(
+  raw: S2Input | null,
+  incidents: NormalisedIncident[],
+  trace: string[],
+  warnings: string[]
+): number {
+  const totalWorkers = raw?.valueChainWorkersCount ?? null
+  let penalty = 0
+
+  incidents.forEach((incident) => {
+    const severity = incident.severityLevel ?? 'medium'
+    const severityWeight = s2.severityWeights[severity]
+    const statusMultiplier = resolveStatusMultiplier(incident.remediationStatus)
+    const ratio = resolveIncidentScale(incident.workersAffected, totalWorkers, s2.defaultIncidentScale)
+
+    penalty += severityWeight * statusMultiplier * ratio
+
+    if (incident.severityLevel === 'high' && incident.remediationStatus !== 'completed') {
+      warnings.push(
+        `Højrisiko-hændelsen "${formatLabel(incident.supplier ?? incident.country ?? 'Ukendt')}" er ikke fuldt afhjulpet.`
+      )
+    }
+
+    if (incident.remediationStatus == null) {
+      warnings.push(`Angiv remedieringsstatus for hændelsen på ${formatLabel(incident.supplier ?? 'leverandør')}.`)
+    }
+
+    if (incident.workersAffected != null && totalWorkers != null && totalWorkers > 0) {
+      const share = (incident.workersAffected / totalWorkers) * 100
+      if (share >= 10) {
+        warnings.push(
+          `${incident.workersAffected} arbejdstagere påvirket hos ${formatLabel(incident.supplier ?? 'leverandør')} – dokumentér kompensation og opfølgning.`
+        )
+      }
+      trace.push(`incidentShare[${incident.index}]=${share.toFixed(1)}`)
+    }
+
+    trace.push(
+      `incident[${incident.index}]=${formatLabel(incident.supplier ?? incident.country ?? 'ukendt')}|type=${
+        incident.issueType ?? 'null'
+      }|severity=${incident.severityLevel ?? 'null'}|status=${incident.remediationStatus ?? 'null'}|workers=${
+        incident.workersAffected ?? 'null'
+      }`
+    )
+  })
+
+  return penalty
+}
+
+function computeGrievancePenalty(raw: S2Input | null, trace: string[], warnings: string[]): number {
+  const open = clampCount(raw?.grievancesOpenCount)
+  if (open == null) {
+    return 0
+  }
+
+  trace.push(`grievancesOpenCount=${open}`)
+  if (open > 0) {
+    warnings.push(`${open} klager fra leverandørarbejdere er åbne. Følg op og luk dem for at undgå ESRS S2 advarsler.`)
+  }
+
+  return open * s2.openGrievancePenaltyPerCase
+}
+
+function normaliseIncidents(rows: S2Input['incidents']): NormalisedIncident[] {
   if (!Array.isArray(rows)) {
     return []
   }
 
   return rows
     .map((row, index) => {
-      const level = (row?.level ?? '').trim()
-      const femalePercent = clampPercent(row?.femalePercent)
-      const malePercent = clampPercent(row?.malePercent)
-      const otherPercent = clampPercent(row?.otherPercent)
-      const payGapPercent = clampNumber(row?.payGapPercent, -100, 100)
-      const narrative = row?.targetNarrative == null ? null : row.targetNarrative.trim() || null
-
-      if (level.length === 0) {
+      if (row == null) {
         return null
       }
 
       return {
         index,
-        level,
-        femalePercent,
-        malePercent,
-        otherPercent,
-        payGapPercent,
-        narrative
+        supplier: row.supplier == null ? null : row.supplier.trim() || null,
+        country: row.country == null ? null : row.country.trim() || null,
+        issueType: row.issueType ?? null,
+        workersAffected: clampCount(row.workersAffected),
+        severityLevel: row.severityLevel ?? null,
+        remediationStatus: row.remediationStatus ?? null,
+        description: row.description == null ? null : row.description.trim() || null
       }
     })
-    .filter((row): row is NormalisedRow => row != null)
+    .filter((row): row is NormalisedIncident => row != null)
 }
 
-function resolveCoverage(raw: S2Input | null, rows: NormalisedRow[]): number | null {
-  const explicit = clampPercent(raw?.dataCoveragePercent)
-  if (explicit != null) {
-    return explicit
+function resolveStatusMultiplier(status: NormalisedStatus): number {
+  if (status === 'completed') {
+    return s2.resolvedMitigation
   }
-
-  const ratio = rows.filter((row) => row.femalePercent != null || row.malePercent != null).length / (rows.length || 1)
-  const percent = Math.round(ratio * 100)
-  return rows.length === 0 ? null : percent
+  if (status === 'inProgress') {
+    return s2.inProgressMitigation
+  }
+  return 1
 }
 
-function computeParityGap(row: NormalisedRow): number | null {
-  if (row.femalePercent == null && row.malePercent == null) {
-    return null
+function resolveIncidentScale(
+  workersAffected: number | null,
+  totalWorkers: number | null,
+  fallback: number
+): number {
+  if (workersAffected != null) {
+    if (totalWorkers != null && totalWorkers > 0) {
+      return Math.min(1, workersAffected / totalWorkers)
+    }
+    return Math.min(1, workersAffected / 500)
   }
-  const female = row.femalePercent ?? (row.malePercent != null ? 100 - row.malePercent : null)
-  if (female == null) {
-    return null
+
+  if (totalWorkers != null && totalWorkers > 0) {
+    return Math.min(1, fallback * Math.max(1, totalWorkers / 500))
   }
-  return Math.abs(female - s2.fullParityPercent)
+
+  return fallback
 }
 
-function clampPercent(value: number | null | undefined): number | null {
-  if (value == null || Number.isNaN(value)) {
-    return null
-  }
-  return Math.max(0, Math.min(100, Number(value)))
-}
-
-function clampNumber(value: number | null | undefined, min: number, max: number): number | null {
-  if (value == null || Number.isNaN(value)) {
-    return null
-  }
-  return Math.max(min, Math.min(max, Number(value)))
-}
-
-function normalisePercent(value: number | null): number {
-  if (value == null) {
+function normalisePercent(value: PercentLike): number {
+  if (value == null || Number.isNaN(Number(value))) {
     return 0
   }
-  return Math.max(0, Math.min(1, value / 100))
+  return Math.max(0, Math.min(1, Number(value) / 100))
 }
 
-function encodeTrace(value: string): string {
-  return value.replaceAll('|', '/').replaceAll('\n', ' ')
+function clampPercent(value: PercentLike): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
+  }
+  const numeric = Number(value)
+  return Math.max(0, Math.min(100, numeric))
+}
+
+function clampCount(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
+  }
+  const numeric = Math.max(0, Math.floor(Number(value)))
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+function formatLabel(label: string): string {
+  return label.replaceAll('|', '/').replaceAll('\n', ' ').trim()
 }

--- a/packages/shared/calculations/modules/runS2.ts
+++ b/packages/shared/calculations/modules/runS2.ts
@@ -8,11 +8,12 @@ const { s2 } = factors
 
 type IncidentRow = NonNullable<S2Input['incidents']>[number]
 
+type NormalisedIssueType = NonNullable<IncidentRow['issueType']> | null
 type NormalisedIncident = {
   index: number
   supplier: string | null
   country: string | null
-  issueType: string | null
+  issueType: NormalisedIssueType
   workersAffected: number | null
   severityLevel: NormalisedSeverity
   remediationStatus: NormalisedStatus

--- a/packages/shared/calculations/modules/runS2.ts
+++ b/packages/shared/calculations/modules/runS2.ts
@@ -48,8 +48,9 @@ export function runS2(input: ModuleInput): ModuleResult {
     s2.auditWeight * auditScore +
     s2.grievanceWeight * mechanismScore
 
-  const penalty = s2.incidentWeight * Math.min(1, incidentPenalty + grievancePenalty)
-  const value = Number((Math.max(0, Math.min(1, baseScore - penalty)) * 100).toFixed(s2.resultPrecision))
+  const penaltyRatio = Math.min(1, incidentPenalty + grievancePenalty)
+  const incidentScore = s2.incidentWeight * (1 - penaltyRatio)
+  const value = Number((Math.max(0, Math.min(1, baseScore + incidentScore)) * 100).toFixed(s2.resultPrecision))
 
   if (incidents.length === 0) {
     trace.push('incidents=0')

--- a/packages/shared/calculations/modules/runS3.ts
+++ b/packages/shared/calculations/modules/runS3.ts
@@ -49,7 +49,9 @@ export function runS3(input: ModuleInput): ModuleResult {
     s3.grievanceWeight * grievanceScore +
     s3.engagementWeight * engagementScore
 
-  const value = Number((Math.max(0, Math.min(1, baseScore - s3.incidentWeight * Math.min(1, incidentPenalty))) * 100).toFixed(s3.resultPrecision))
+  const penaltyRatio = Math.min(1, incidentPenalty)
+  const incidentScore = s3.incidentWeight * (1 - penaltyRatio)
+  const value = Number((Math.max(0, Math.min(1, baseScore + incidentScore)) * 100).toFixed(s3.resultPrecision))
 
   if (impacts.length === 0) {
     trace.push('impacts=0')

--- a/packages/shared/calculations/modules/runS3.ts
+++ b/packages/shared/calculations/modules/runS3.ts
@@ -1,105 +1,65 @@
 /**
- * Beregning for modul S3 – arbejdsmiljø og hændelser.
+ * Beregning for modul S3 – berørte lokalsamfund.
  */
 import type { ModuleInput, ModuleResult, S3Input } from '../../types'
 import { factors } from '../factors'
 
 const { s3 } = factors
 
-type IncidentRow = NonNullable<S3Input['incidents']>[number]
+type ImpactRow = NonNullable<S3Input['incidents']>[number]
 
-type NormalisedIncident = {
+type NormalisedImpact = {
   index: number
-  type: NonNullable<IncidentRow['incidentType']>
-  count: number
-  ratePerMillionHours: number | null
+  community: string | null
+  geography: string | null
+  impactType: string | null
+  householdsAffected: number | null
+  severityLevel: NormalisedSeverity
+  remediationStatus: NormalisedStatus
   description: string | null
-  rootCauseClosed: boolean | null
 }
 
-const severityWeights: Record<NormalisedIncident['type'], number> = {
-  fatality: s3.fatalityPenalty,
-  lostTime: s3.lostTimePenalty,
-  recordable: s3.recordablePenalty,
-  nearMiss: -s3.nearMissCredit
-}
+type NormalisedSeverity = NonNullable<ImpactRow['severityLevel']> | null
+type NormalisedStatus = NonNullable<ImpactRow['remediationStatus']> | null
+
+type PercentLike = number | null | undefined
+
+type NarrativeField = 'engagementNarrative' | 'remedyNarrative'
 
 export function runS3(input: ModuleInput): ModuleResult {
   const raw = (input.S3 ?? null) as S3Input | null
-  const incidents = normaliseIncidents(raw?.incidents)
+  const impacts = normaliseImpacts(raw?.incidents)
   const trace: string[] = []
   const warnings: string[] = []
   const assumptions = [
-    'Scoren starter ved 100 og reduceres efter vægtede hændelser (fatalitet 45, lost time 18, recordable 8).',
-    'Near-miss rapportering giver et mindre plus (2 point) da proaktiv rapportering understøtter forebyggelse.',
-    'Baseline eksponering er millioner arbejdstimer; målet er max 3 vægtede hændelser pr. million timer.'
+    'Scoren vægter dækning af konsekvensanalyser (35 %), andel højrisiko-lokalsamfund (20 %), håndtering af klager (15 %) og engagement/narrativ (15 %).',
+    'Registrerede impacts reducerer score afhængigt af alvorlighed, antal husholdninger og status på remediering.'
   ]
 
-  const hoursWorked = resolveNumber(raw?.totalHoursWorked)
-  if (hoursWorked != null) {
-    trace.push(`hoursWorked=${hoursWorked}`)
-  }
+  const assessmentScore = resolveAssessmentScore(raw, trace, warnings)
+  const highRiskScore = resolveHighRiskScore(raw, trace, warnings)
+  const grievanceScore = resolveGrievanceScore(raw, trace, warnings)
+  const engagementScore = resolveNarrativeScore(raw, 'engagementNarrative', warnings)
+  const incidentPenalty = computeIncidentPenalty(raw, impacts, trace, warnings)
 
-  if (raw?.safetyCertification === true) {
-    assumptions.push('ISO 45001 eller tilsvarende certificering udløser +10 bonuspoint.')
-  } else if (raw?.safetyCertification === false) {
-    warnings.push('Ingen arbejdsmiljøcertificering markeret. Overvej ISO 45001 eller tilsvarende.')
-  } else {
-    warnings.push('Angiv om der er arbejdsmiljøcertificering – bruges som CSRD-kvalitetsindikator.')
-  }
+  const baseScore =
+    s3.assessmentWeight * assessmentScore +
+    s3.highRiskWeight * highRiskScore +
+    s3.grievanceWeight * grievanceScore +
+    s3.engagementWeight * engagementScore
 
-  if (incidents.length === 0) {
-    warnings.push('Ingen hændelser registreret. Bekræft at nul hændelser er korrekt, og angiv observationer hvis muligt.')
-    trace.push('incidents=0')
-  }
+  const value = Number((Math.max(0, Math.min(1, baseScore - s3.incidentWeight * Math.min(1, incidentPenalty))) * 100).toFixed(s3.resultPrecision))
 
-  let weightedPenalty = 0
-
-  incidents.forEach((incident) => {
-    const weight = severityWeights[incident.type]
-    const contribution = incident.count * weight
-    weightedPenalty += contribution
-
-    if (incident.type === 'fatality' && incident.count > 0) {
-      warnings.push('Fataliteter registreret – CSRD kræver detaljeret redegørelse og handlingsplan.')
+  if (impacts.length === 0) {
+    trace.push('impacts=0')
+    if ((raw?.highRiskCommunitySharePercent ?? 0) > 0) {
+      warnings.push('Ingen påvirkninger er registreret, men der er angivet højrisiko-lokalsamfund. Bekræft konsekvensanalysen.')
     }
-
-    if (incident.type !== 'nearMiss' && incident.rootCauseClosed === false) {
-      warnings.push(
-        `Hændelsen "${incident.type}" (index ${incident.index + 1}) mangler lukket rodårsagsanalyser. Følg op med corrective actions.`
-      )
-    }
-
-    if (incident.ratePerMillionHours != null) {
-      trace.push(`rate[${incident.index}]=${incident.ratePerMillionHours}`)
-      if (incident.ratePerMillionHours > s3.baselineTargetRate * 2) {
-        warnings.push(
-          `Hændelsesraten for ${incident.type} (${incident.ratePerMillionHours} pr. mio. timer) overstiger ESRS-retningslinjerne.`
-        )
-      }
-    }
-
-    trace.push(
-      `incident[${incident.index}]=${incident.type}|count=${incident.count}|rootCause=${incident.rootCauseClosed}`
-    )
-  })
-
-  const exposure = Math.max(
-    1,
-    hoursWorked == null || hoursWorked <= 0 ? 1 : hoursWorked / s3.baselineHoursDivisor
-  )
-  const severityIndex = weightedPenalty / exposure
-  trace.push(`weightedPenalty=${weightedPenalty.toFixed(2)}`)
-  trace.push(`severityIndex=${severityIndex.toFixed(2)}`)
-
-  const severityScore = Math.max(0, 1 - severityIndex / s3.ratePenaltyMultiplier)
-  let value = severityScore * 100
-
-  if (raw?.safetyCertification === true) {
-    value += s3.certificationBonus
   }
 
-  value = Number(Math.max(0, Math.min(100, value)).toFixed(s3.resultPrecision))
+  if (needsDetailedNarrative(raw, 'remedyNarrative')) {
+    warnings.push('Tilføj narrativ om afhjælpning og samarbejde med lokalsamfund (ESRS S3 §23-27).')
+  }
 
   return {
     value,
@@ -110,33 +70,174 @@ export function runS3(input: ModuleInput): ModuleResult {
   }
 }
 
-function normaliseIncidents(rows: S3Input['incidents']): NormalisedIncident[] {
+function resolveAssessmentScore(raw: S3Input | null, trace: string[], warnings: string[]): number {
+  const percent = clampPercent(raw?.impactAssessmentsCoveragePercent)
+  if (percent == null) {
+    warnings.push('Angiv andel af aktiviteter med lokalsamfundsvurderinger (ESRS S3 datapunkt S3-2).')
+    return 0
+  }
+  trace.push(`impactAssessmentsCoveragePercent=${percent}`)
+  if (percent < s3.assessmentWarningThresholdPercent) {
+    warnings.push(`Konsekvensanalyser dækker kun ${percent}% af aktiviteterne – øg dækningen for at reducere risiko.`)
+  }
+  return normalisePercent(percent)
+}
+
+function resolveHighRiskScore(raw: S3Input | null, trace: string[], warnings: string[]): number {
+  const share = clampPercent(raw?.highRiskCommunitySharePercent)
+  if (share == null) {
+    warnings.push('Angiv andelen af lokalsamfund klassificeret som højrisiko.')
+    return 0.5
+  }
+  trace.push(`highRiskCommunitySharePercent=${share}`)
+  if (share > s3.highRiskWarningThresholdPercent) {
+    warnings.push(`Højrisiko-lokalsamfund udgør ${share}% – styrk due diligence og engagement.`)
+  }
+  return Math.max(0, 1 - normalisePercent(share))
+}
+
+function resolveGrievanceScore(raw: S3Input | null, trace: string[], warnings: string[]): number {
+  const open = clampCount(raw?.grievancesOpenCount)
+  if (open == null) {
+    return 1
+  }
+  trace.push(`grievancesOpenCount=${open}`)
+  if (open > 0) {
+    warnings.push(`${open} klager fra lokalsamfund er åbne – dokumentér plan for lukning.`)
+  }
+  return Math.max(0, 1 - open * s3.openGrievancePenaltyPerCase)
+}
+
+function resolveNarrativeScore(raw: S3Input | null, field: NarrativeField, warnings: string[]): number {
+  const value = raw?.[field]
+  if (value == null || value.trim().length === 0) {
+    warnings.push('Tilføj narrativ dialog med lokalsamfund og dokumentér processer (ESRS S3 §21).')
+    return 0.3
+  }
+  const length = value.trim().length
+  if (length < 80) {
+    warnings.push('Narrativet for lokalsamfund er meget kort – uddybt beskrivelse anbefales.')
+    return 0.6
+  }
+  return Math.min(1, length / 400)
+}
+
+function needsDetailedNarrative(raw: S3Input | null, field: NarrativeField): boolean {
+  const value = raw?.[field]
+  return value == null || value.trim().length < 60
+}
+
+function computeIncidentPenalty(
+  raw: S3Input | null,
+  impacts: NormalisedImpact[],
+  trace: string[],
+  warnings: string[]
+): number {
+  const baselineCommunities = raw?.communitiesIdentifiedCount ?? null
+  let penalty = 0
+
+  impacts.forEach((impact) => {
+    const severity = impact.severityLevel ?? 'medium'
+    const severityWeight = s3.severityWeights[severity]
+    const statusMultiplier = resolveStatusMultiplier(impact.remediationStatus)
+    const ratio = resolveImpactScale(impact.householdsAffected, baselineCommunities)
+
+    penalty += severityWeight * statusMultiplier * ratio
+
+    if (impact.severityLevel === 'high' && impact.remediationStatus !== 'completed') {
+      warnings.push(`Højrisiko-påvirkningen ved ${formatLabel(impact.community ?? 'lokalsamfund')} er ikke fuldt afhjulpet.`)
+    }
+
+    if (impact.remediationStatus == null) {
+      warnings.push(`Angiv remedieringsstatus for påvirkningen ved ${formatLabel(impact.community ?? 'lokalsamfund')}.`)
+    }
+
+    if (impact.householdsAffected != null) {
+      trace.push(`householdsAffected[${impact.index}]=${impact.householdsAffected}`)
+      if (impact.householdsAffected >= 50) {
+        warnings.push(
+          `${impact.householdsAffected} husholdninger berørt i ${formatLabel(impact.community ?? 'lokalsamfund')} – dokumentér kompenserende handlinger.`
+        )
+      }
+    }
+
+    trace.push(
+      `impact[${impact.index}]=${formatLabel(impact.community ?? impact.geography ?? 'ukendt')}|type=${
+        impact.impactType ?? 'null'
+      }|severity=${impact.severityLevel ?? 'null'}|status=${impact.remediationStatus ?? 'null'}|households=${
+        impact.householdsAffected ?? 'null'
+      }`
+    )
+  })
+
+  return penalty
+}
+
+function normaliseImpacts(rows: S3Input['incidents']): NormalisedImpact[] {
   if (!Array.isArray(rows)) {
     return []
   }
 
   return rows
     .map((row, index) => {
-      const type = row?.incidentType
-      const count = resolveNumber(row?.count) ?? 0
-      if (type == null || count < 0) {
+      if (row == null) {
         return null
       }
+
       return {
         index,
-        type,
-        count,
-        ratePerMillionHours: resolveNumber(row?.ratePerMillionHours),
-        description: row?.description == null ? null : row.description.trim() || null,
-        rootCauseClosed: row?.rootCauseClosed ?? null
+        community: row.community == null ? null : row.community.trim() || null,
+        geography: row.geography == null ? null : row.geography.trim() || null,
+        impactType: row.impactType ?? null,
+        householdsAffected: clampCount(row.householdsAffected),
+        severityLevel: row.severityLevel ?? null,
+        remediationStatus: row.remediationStatus ?? null,
+        description: row.description == null ? null : row.description.trim() || null
       }
     })
-    .filter((row): row is NormalisedIncident => row != null)
+    .filter((row): row is NormalisedImpact => row != null)
 }
 
-function resolveNumber(value: number | null | undefined): number | null {
-  if (value == null || Number.isNaN(value)) {
+function resolveStatusMultiplier(status: NormalisedStatus): number {
+  if (status === 'completed') {
+    return s3.resolvedMitigation
+  }
+  if (status === 'inProgress') {
+    return s3.inProgressMitigation
+  }
+  return 1
+}
+
+function resolveImpactScale(householdsAffected: number | null, baselineCommunities: number | null): number {
+  if (householdsAffected != null) {
+    return Math.min(1, householdsAffected / 500)
+  }
+  if (baselineCommunities != null && baselineCommunities > 0) {
+    return Math.min(1, s3.defaultIncidentScale * Math.max(1, baselineCommunities / 5))
+  }
+  return s3.defaultIncidentScale
+}
+
+function clampPercent(value: PercentLike): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
     return null
   }
-  return Number(value)
+  const numeric = Number(value)
+  return Math.max(0, Math.min(100, numeric))
+}
+
+function normalisePercent(value: number): number {
+  return Math.max(0, Math.min(1, value / 100))
+}
+
+function clampCount(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
+  }
+  const numeric = Math.max(0, Math.floor(Number(value)))
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+function formatLabel(label: string): string {
+  return label.replaceAll('|', '/').replaceAll('\n', ' ').trim()
 }

--- a/packages/shared/calculations/modules/runS3.ts
+++ b/packages/shared/calculations/modules/runS3.ts
@@ -8,11 +8,12 @@ const { s3 } = factors
 
 type ImpactRow = NonNullable<S3Input['incidents']>[number]
 
+type NormalisedImpactType = NonNullable<ImpactRow['impactType']> | null
 type NormalisedImpact = {
   index: number
   community: string | null
   geography: string | null
-  impactType: string | null
+  impactType: NormalisedImpactType
   householdsAffected: number | null
   severityLevel: NormalisedSeverity
   remediationStatus: NormalisedStatus

--- a/packages/shared/calculations/modules/runS4.ts
+++ b/packages/shared/calculations/modules/runS4.ts
@@ -48,11 +48,9 @@ export function runS4(input: ModuleInput): ModuleResult {
     s4.mechanismWeight * mechanismScore +
     s4.dataProtectionWeight * dataProtectionScore
 
-  const value = Number(
-    (
-      Math.max(0, Math.min(1, baseScore - s4.incidentWeight * Math.min(1, incidentPenalty + additionalPenalty))) * 100
-    ).toFixed(s4.resultPrecision)
-  )
+  const penaltyRatio = Math.min(1, incidentPenalty + additionalPenalty)
+  const incidentScore = s4.incidentWeight * (1 - penaltyRatio)
+  const value = Number((Math.max(0, Math.min(1, baseScore + incidentScore)) * 100).toFixed(s4.resultPrecision))
 
   if (issues.length === 0) {
     trace.push('issues=0')

--- a/packages/shared/calculations/modules/runS4.ts
+++ b/packages/shared/calculations/modules/runS4.ts
@@ -1,93 +1,71 @@
 /**
- * Beregning for modul S4 – due diligence og menneskerettigheder.
+ * Beregning for modul S4 – forbrugere og slutbrugere.
  */
 import type { ModuleInput, ModuleResult, S4Input } from '../../types'
 import { factors } from '../factors'
 
 const { s4 } = factors
 
-type ProcessRow = NonNullable<S4Input['processes']>[number]
+type IssueRow = NonNullable<S4Input['issues']>[number]
 
-type NormalisedProcess = {
+type NormalisedIssue = {
   index: number
-  area: string
-  coveragePercent: number | null
-  lastAssessmentDate: string | null
-  severityLevel: NonNullable<ProcessRow['severityLevel']> | null
-  remediationPlan: string | null
+  productOrService: string | null
+  market: string | null
+  issueType: string | null
+  usersAffected: number | null
+  severityLevel: NormalisedSeverity
+  remediationStatus: NormalisedStatus
+  description: string | null
 }
 
-const severityPenaltyMap: Record<NonNullable<ProcessRow['severityLevel']>, number> = {
-  high: s4.highRiskPenalty,
-  medium: s4.mediumRiskPenalty,
-  low: 0
-}
+type NormalisedSeverity = NonNullable<IssueRow['severityLevel']> | null
+type NormalisedStatus = NonNullable<IssueRow['remediationStatus']> | null
+
+type PercentLike = number | null | undefined
 
 export function runS4(input: ModuleInput): ModuleResult {
   const raw = (input.S4 ?? null) as S4Input | null
-  const processes = normaliseProcesses(raw?.processes)
+  const issues = normaliseIssues(raw?.issues)
   const trace: string[] = []
   const warnings: string[] = []
   const assumptions = [
-    'Scoren kombinerer dækning af due diligence (60 %), håndtering af højrisiko-områder (20 %) og klage-/escalationsmekanisme (20 %).',
-    'Højrisiko uden remediationsplan giver størst fradrag. Medium risiko giver mindre fradrag.'
+    'Scoren vægter risikovurdering af produkter (30 %), klagehåndtering (20 %), klagemekanismer (10 %) og databeskyttelse (15 %).',
+    'Indberettede hændelser reducerer scoren efter alvorlighed, antal berørte brugere og status på afhjælpning.'
   ]
 
-  const coverageAverage = computeAverage(processes.map((process) => process.coveragePercent))
-  if (coverageAverage == null) {
-    warnings.push('Angiv dækningsgrad for due diligence-processer – CSRD kræver fuld oversigt over værdikæden.')
-  } else {
-    trace.push(`coverageAverage=${coverageAverage}`)
-    if (coverageAverage < 70) {
-      warnings.push('Due diligence dækker under 70 % af værdikæden. Dokumenter plan for fuld dækning.')
+  const coverageScore = resolveCoverageScore(raw, trace, warnings)
+  const complaintsScore = resolveComplaintsScore(raw, trace, warnings)
+  const mechanismScore = resolveMechanismScore(raw, warnings)
+  const dataProtectionScore = resolveDataProtectionScore(raw, trace, warnings)
+  const incidentPenalty = computeIncidentPenalty(raw, issues, trace, warnings)
+  const additionalPenalty = computeAdditionalPenalty(raw, trace, warnings)
+
+  const baseScore =
+    s4.coverageWeight * coverageScore +
+    s4.complaintResolutionWeight * complaintsScore +
+    s4.mechanismWeight * mechanismScore +
+    s4.dataProtectionWeight * dataProtectionScore
+
+  const value = Number(
+    (
+      Math.max(0, Math.min(1, baseScore - s4.incidentWeight * Math.min(1, incidentPenalty + additionalPenalty))) * 100
+    ).toFixed(s4.resultPrecision)
+  )
+
+  if (issues.length === 0) {
+    trace.push('issues=0')
+    if ((raw?.severeIncidentsCount ?? 0) > 0) {
+      warnings.push('Der er registreret alvorlige hændelser, men ingen detaljeret liste. Udfyld S4 impacts-tabellen.')
     }
   }
 
-  const grievanceScore = resolveGrievanceScore(raw, warnings)
-
-  const severityPenalty = processes.reduce((penalty, process) => {
-    if (process.severityLevel == null) {
-      warnings.push(`Vurder risikoniveau for "${process.area}" for at kunne dokumentere prioritering.`)
-      return penalty
-    }
-
-    const basePenalty = severityPenaltyMap[process.severityLevel]
-    const hasPlan = process.remediationPlan != null && process.remediationPlan.length > 0
-
-    if (!hasPlan && basePenalty > 0) {
-      warnings.push(`Højrisiko-området "${process.area}" mangler remediationsplan.`)
-    }
-
-    if (hasPlan && process.severityLevel === 'high') {
-      trace.push(`remediation[${process.index}]=plan`)
-    }
-
-    return penalty + (hasPlan ? basePenalty / 2 : basePenalty)
-  }, 0)
-
-  trace.push(`severityPenalty=${severityPenalty.toFixed(2)}`)
-
-  const coverageScore = normalisePercent(coverageAverage)
-  const severityScore = Math.max(0, 1 - Math.min(1, severityPenalty))
-
-  const totalScore = s4.coverageWeight * coverageScore + s4.severityWeight * severityScore + s4.grievanceWeight * grievanceScore
-  const value = Number((Math.max(0, Math.min(totalScore, 1)) * 100).toFixed(s4.resultPrecision))
-
-  if (processes.length === 0) {
-    warnings.push('Ingen due diligence-processer registreret. Tilføj fx menneskerettigheder, leverandørstyring eller whistleblower.')
-    trace.push('processes=0')
+  if (!hasNarrative(raw?.vulnerableUsersNarrative)) {
+    warnings.push('Tilføj narrativ om støtte til udsatte brugergrupper og adgang til produkter (ESRS S4 §18).')
   }
 
-  processes.forEach((process) => {
-    trace.push(
-      `process[${process.index}]=${encodeTrace(process.area)}|coverage=${process.coveragePercent ?? 'null'}|severity=${
-        process.severityLevel ?? 'null'
-      }`
-    )
-  })
-
-  if (raw?.dueDiligenceNarrative == null || raw.dueDiligenceNarrative.trim().length < 40) {
-    warnings.push('Tilføj en narrativ beskrivelse af due diligence-processerne for at opfylde ESRS S1/S4 disclosures.')
+  if (!hasNarrative(raw?.consumerEngagementNarrative)) {
+    warnings.push('Tilføj narrativ om forbrugerkommunikation, uddannelse og samarbejde (ESRS S4 §22).')
   }
 
   return {
@@ -99,71 +77,226 @@ export function runS4(input: ModuleInput): ModuleResult {
   }
 }
 
-function normaliseProcesses(rows: S4Input['processes']): NormalisedProcess[] {
+function resolveCoverageScore(raw: S4Input | null, trace: string[], warnings: string[]): number {
+  const percent = clampPercent(raw?.productsAssessedPercent)
+  if (percent == null) {
+    warnings.push('Angiv andel af produkter/tjenester med risikovurdering (ESRS S4 datapunkt S4-2).')
+    return 0
+  }
+  trace.push('productsAssessedPercent=' + percent)
+  if (percent < s4.productsCoverageWarningPercent) {
+    warnings.push(
+      'Kun ' +
+        percent +
+        '% af produkterne er risikovurderet – udvid processerne for at dække hele porteføljen.'
+    )
+  }
+  return normalisePercent(percent)
+}
+
+function resolveComplaintsScore(raw: S4Input | null, trace: string[], warnings: string[]): number {
+  const percent = clampPercent(raw?.complaintsResolvedPercent)
+  if (percent == null) {
+    warnings.push('Angiv hvor stor en andel af klager der løses inden for SLA.')
+    return 0.5
+  }
+  trace.push('complaintsResolvedPercent=' + percent)
+  if (percent < s4.complaintResolutionWarningPercent) {
+    warnings.push('Kun ' + percent + '% af klagerne løses rettidigt – styrk kundeserviceprocesser.')
+  }
+  return normalisePercent(percent)
+}
+
+function resolveMechanismScore(raw: S4Input | null, warnings: string[]): number {
+  if (raw?.grievanceMechanismInPlace == null) {
+    warnings.push('Angiv om der findes klagemekanisme for forbrugere/slutbrugere.')
+    return 0.5
+  }
+  if (raw.grievanceMechanismInPlace === false) {
+    warnings.push('Ingen klagemekanisme markeret. Etabler hotline eller digitale kontaktpunkter.')
+    return 0
+  }
+  if (raw.escalationTimeframeDays != null && raw.escalationTimeframeDays > s4.escalationWarningDays) {
+    warnings.push(
+      'Behandlingstiden for klager er ' +
+        raw.escalationTimeframeDays +
+        ' dage – reducer til under ' +
+        s4.escalationWarningDays +
+        ' dage.'
+    )
+  }
+  return 1
+}
+
+function resolveDataProtectionScore(raw: S4Input | null, trace: string[], warnings: string[]): number {
+  const breaches = clampCount(raw?.dataBreachesCount)
+  if (breaches == null) {
+    warnings.push('Angiv antal registrerede brud på datasikkerhed (ESRS S4 datapunkt S4-4).')
+    return 0.6
+  }
+  trace.push('dataBreachesCount=' + breaches)
+  if (breaches > 0) {
+    warnings.push(
+      String(breaches) +
+        ' brud på datasikkerhed registreret – gennemgå kontroller og underret relevante myndigheder.'
+    )
+  }
+  return Math.max(0, 1 - breaches * 0.15)
+}
+
+function computeIncidentPenalty(
+  raw: S4Input | null,
+  issues: NormalisedIssue[],
+  trace: string[],
+  warnings: string[]
+): number {
+  let penalty = 0
+
+  issues.forEach((issue) => {
+    const severity = issue.severityLevel ?? 'medium'
+    const severityWeight = s4.severityWeights[severity]
+    const statusMultiplier = resolveStatusMultiplier(issue.remediationStatus)
+    const ratio = resolveIssueScale(issue.usersAffected)
+
+    penalty += severityWeight * statusMultiplier * ratio
+
+    if (issue.severityLevel === 'high' && issue.remediationStatus !== 'completed') {
+      warnings.push(
+        'Højrisiko-hændelsen for ' +
+          formatLabel(issue.productOrService ?? 'produkt') +
+          ' er ikke fuldt afhjulpet.'
+      )
+    }
+
+    if (issue.remediationStatus == null) {
+      warnings.push(
+        'Angiv remedieringsstatus for hændelsen på ' +
+          formatLabel(issue.productOrService ?? 'produkt') +
+          '.'
+      )
+    }
+
+    if (issue.usersAffected != null) {
+      trace.push('usersAffected[' + issue.index + ']=' + issue.usersAffected)
+      if (issue.usersAffected >= 500) {
+        warnings.push(
+          issue.usersAffected +
+            ' brugere påvirket af ' +
+            formatLabel(issue.productOrService ?? 'produkt') +
+            ' – beskriv tilbagekaldelse og kompensation.'
+        )
+      }
+    }
+
+    trace.push(
+      'issue[' +
+        issue.index +
+        ']=' +
+        formatLabel(issue.productOrService ?? issue.market ?? 'ukendt') +
+        '|type=' +
+        (issue.issueType ?? 'null') +
+        '|severity=' +
+        (issue.severityLevel ?? 'null') +
+        '|status=' +
+        (issue.remediationStatus ?? 'null') +
+        '|users=' +
+        (issue.usersAffected ?? 'null')
+    )
+  })
+
+  return penalty
+}
+
+function computeAdditionalPenalty(raw: S4Input | null, trace: string[], warnings: string[]): number {
+  const severe = clampCount(raw?.severeIncidentsCount) ?? 0
+  const recalls = clampCount(raw?.recallsCount) ?? 0
+
+  trace.push('severeIncidentsCount=' + severe)
+  trace.push('recallsCount=' + recalls)
+
+  if (severe > 0) {
+    warnings.push(
+      String(severe) +
+        ' alvorlige hændelser rapporteret – offentliggør detaljer og kompensation.'
+    )
+  }
+
+  if (recalls > 0) {
+    warnings.push(
+      String(recalls) +
+        ' produkt-/service-recalls registreret. Sikr dokumentation for forløb og kommunikation.'
+    )
+  }
+
+  return severe * (s4.defaultIncidentScale * 2) + recalls * 0.05
+}
+
+function normaliseIssues(rows: S4Input['issues']): NormalisedIssue[] {
   if (!Array.isArray(rows)) {
     return []
   }
 
   return rows
     .map((row, index) => {
-      const area = (row?.area ?? '').trim()
-      if (area.length === 0) {
+      if (row == null) {
         return null
       }
 
       return {
         index,
-        area,
-        coveragePercent: clampPercent(row?.coveragePercent),
-        lastAssessmentDate: row?.lastAssessmentDate == null ? null : row.lastAssessmentDate.trim() || null,
-        severityLevel: row?.severityLevel ?? null,
-        remediationPlan: row?.remediationPlan == null ? null : row.remediationPlan.trim() || null
+        productOrService: row.productOrService == null ? null : row.productOrService.trim() || null,
+        market: row.market == null ? null : row.market.trim() || null,
+        issueType: row.issueType ?? null,
+        usersAffected: clampCount(row.usersAffected),
+        severityLevel: row.severityLevel ?? null,
+        remediationStatus: row.remediationStatus ?? null,
+        description: row.description == null ? null : row.description.trim() || null
       }
     })
-    .filter((row): row is NormalisedProcess => row != null)
+    .filter((row): row is NormalisedIssue => row != null)
 }
 
-function computeAverage(values: Array<number | null>): number | null {
-  const valid = values.filter((value): value is number => value != null && Number.isFinite(value))
-  if (valid.length === 0) {
-    return null
+function resolveStatusMultiplier(status: NormalisedStatus): number {
+  if (status === 'completed') {
+    return s4.resolvedMitigation
   }
-  const sum = valid.reduce((acc, value) => acc + value, 0)
-  return Number((sum / valid.length).toFixed(1))
-}
-
-function resolveGrievanceScore(raw: S4Input | null, warnings: string[]): number {
-  if (raw?.grievanceMechanismInPlace == null) {
-    warnings.push('Angiv om virksomheden har en klage- og henvendelsesmekanisme. ESRS kræver offentliggørelse.')
-    return 0.3
+  if (status === 'inProgress') {
+    return s4.inProgressMitigation
   }
-
-  if (raw.grievanceMechanismInPlace === false) {
-    warnings.push('Ingen klage-/grievance-mekanisme markeret. Etabler en kanal for medarbejdere og leverandører.')
-    return 0
-  }
-
-  if (raw.escalationTimeframeDays != null && raw.escalationTimeframeDays > 30) {
-    warnings.push('Escalationstiden for klager er over 30 dage. Overvej hurtigere sagsbehandling.')
-  }
-
   return 1
 }
 
-function clampPercent(value: number | null | undefined): number | null {
-  if (value == null || Number.isNaN(value)) {
-    return null
+function resolveIssueScale(usersAffected: number | null): number {
+  if (usersAffected == null) {
+    return s4.defaultIncidentScale
   }
-  return Math.max(0, Math.min(100, Number(value)))
+  return Math.min(1, usersAffected / 1000)
 }
 
-function normalisePercent(value: number | null): number {
-  if (value == null) {
-    return 0
+function clampPercent(value: PercentLike): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
   }
+  const numeric = Number(value)
+  return Math.max(0, Math.min(100, numeric))
+}
+
+function clampCount(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
+  }
+  const numeric = Math.max(0, Math.floor(Number(value)))
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+function normalisePercent(value: number): number {
   return Math.max(0, Math.min(1, value / 100))
 }
 
-function encodeTrace(value: string): string {
-  return value.replaceAll('|', '/').replaceAll('\n', ' ')
+function hasNarrative(value: string | null | undefined): boolean {
+  return value != null && value.trim().length >= 80
+}
+
+function formatLabel(label: string): string {
+  return label.replaceAll('|', '/').replaceAll('\n', ' ').trim()
 }

--- a/packages/shared/calculations/modules/runS4.ts
+++ b/packages/shared/calculations/modules/runS4.ts
@@ -8,11 +8,12 @@ const { s4 } = factors
 
 type IssueRow = NonNullable<S4Input['issues']>[number]
 
+type NormalisedIssueType = NonNullable<IssueRow['issueType']> | null
 type NormalisedIssue = {
   index: number
   productOrService: string | null
   market: string | null
-  issueType: string | null
+  issueType: NormalisedIssueType
   usersAffected: number | null
   severityLevel: NormalisedSeverity
   remediationStatus: NormalisedStatus

--- a/packages/shared/calculations/runModule.ts
+++ b/packages/shared/calculations/runModule.ts
@@ -91,9 +91,9 @@ const moduleTitles: Record<ModuleId, string> = {
   E4Biodiversity: 'E4 – Påvirkning af biodiversitet',
   E5Resources: 'E5 – Ressourcer og materialeforbrug',
   S1: 'S1 – Arbejdsstyrke & headcount',
-  S2: 'S2 – Diversitet og ligestilling',
-  S3: 'S3 – Arbejdsmiljø og hændelser',
-  S4: 'S4 – Due diligence & menneskerettigheder',
+  S2: 'S2 – Værdikædearbejdere',
+  S3: 'S3 – Lokalsamfund og påvirkninger',
+  S4: 'S4 – Forbrugere og slutbrugere',
   G1: 'G1 – Governance-politikker & targets',
   D1: 'D1 – Metode & governance',
   D2: 'D2 – Dobbelt væsentlighed & CSRD-gaps'

--- a/packages/shared/schema/esg-input-schema.json
+++ b/packages/shared/schema/esg-input-schema.json
@@ -2211,18 +2211,27 @@
       "description": "Arbejdskraft og headcount",
       "properties": {
         "reportingYear": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 1900,
           "maximum": 2100,
           "description": "Rapporteringsår for headcount-data."
         },
         "totalHeadcount": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "description": "Samlet antal medarbejdere (headcount)."
         },
         "dataCoveragePercent": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 100,
           "description": "Hvor stor en andel af arbejdsstyrken data dækker."
@@ -2236,23 +2245,35 @@
             "title": "S1HeadcountLine",
             "properties": {
               "segment": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 120,
                 "description": "Navn på segmentet."
               },
               "headcount": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 0,
                 "description": "Headcount i segmentet."
               },
               "femalePercent": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 0,
                 "maximum": 100,
                 "description": "Andel kvinder i procent."
               },
               "collectiveAgreementCoveragePercent": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 0,
                 "maximum": 100,
                 "description": "Dækning af kollektive aftaler eller medarbejderrepræsentation."
@@ -2263,7 +2284,10 @@
           }
         },
         "workforceNarrative": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 2000,
           "description": "Narrativ uddybning af headcount-udviklingen."
         }
@@ -2273,69 +2297,185 @@
     "S2": {
       "type": "object",
       "title": "S2Input",
-      "description": "Diversitet, ligestilling og inklusion",
+      "description": "Værdikædearbejdere og arbejdsforhold",
       "properties": {
-        "genderBalance": {
+        "valueChainWorkersCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Estimeret antal arbejdstagere i værdikæden."
+        },
+        "workersAtRiskCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Antal værdikædearbejdere identificeret som særligt udsatte."
+        },
+        "valueChainCoveragePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af værdikæden der er risikovurderet eller monitoreret."
+        },
+        "highRiskSupplierSharePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af leverandører klassificeret som højrisiko."
+        },
+        "livingWageCoveragePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel værdikædearbejdere dækket af leve-/mindsteløn."
+        },
+        "collectiveBargainingCoveragePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel med adgang til kollektive forhandlinger eller repræsentation."
+        },
+        "socialAuditsCompletedPercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel planlagte sociale audits gennemført i rapporteringsåret."
+        },
+        "grievancesOpenCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Åbne klager fra leverandørarbejdere."
+        },
+        "grievanceMechanismForWorkers": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Om der findes klagemekanisme for leverandørarbejdere."
+        },
+        "incidents": {
           "type": "array",
-          "maxItems": 30,
-          "description": "Kønsfordeling for centrale niveauer.",
+          "maxItems": 40,
+          "description": "Registrerede alvorlige hændelser i værdikæden.",
           "items": {
             "type": "object",
-            "title": "S2DiversityRow",
+            "title": "S2ValueChainIncident",
             "properties": {
-              "level": {
-                "type": ["string", "null"],
+              "supplier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "maxLength": 160,
+                "description": "Leverandør eller site."
+              },
+              "country": {
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 120,
-                "description": "Navn på niveau/gruppe (fx bestyrelse)."
+                "description": "Land eller region."
               },
-              "femalePercent": {
-                "type": ["number", "null"],
+              "issueType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "healthAndSafety",
+                  "wagesAndBenefits",
+                  "workingTime",
+                  "freedomOfAssociation",
+                  "childLabour",
+                  "forcedLabour",
+                  "discrimination",
+                  "other"
+                ],
+                "description": "Kategori for hændelsen."
+              },
+              "workersAffected": {
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 0,
-                "maximum": 100,
-                "description": "Andel kvinder i procent."
+                "description": "Antal berørte arbejdstagere."
               },
-              "malePercent": {
-                "type": ["number", "null"],
-                "minimum": 0,
-                "maximum": 100,
-                "description": "Andel mænd i procent."
+              "severityLevel": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "description": "Vurderet alvorlighed."
               },
-              "otherPercent": {
-                "type": ["number", "null"],
-                "minimum": 0,
-                "maximum": 100,
-                "description": "Andel øvrige/ikke-binære i procent."
+              "remediationStatus": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "notStarted",
+                  "inProgress",
+                  "completed"
+                ],
+                "description": "Status på afhjælpning."
               },
-              "payGapPercent": {
-                "type": ["number", "null"],
-                "minimum": -100,
-                "maximum": 100,
-                "description": "Løngab i procent (kvinder vs. mænd)."
-              },
-              "targetNarrative": {
-                "type": ["string", "null"],
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 500,
-                "description": "Noter om targets/indsatser for niveauet."
+                "description": "Kort beskrivelse af hændelsen."
               }
             },
             "required": [],
             "additionalProperties": false
           }
         },
-        "dataCoveragePercent": {
-          "type": ["number", "null"],
-          "minimum": 0,
-          "maximum": 100,
-          "description": "Andel af arbejdsstyrken med tilgængelige diversitetsdata."
-        },
-        "equalityPolicyInPlace": {
-          "type": ["boolean", "null"],
-          "description": "Angiver om virksomheden har en formaliseret ligestillingspolitik."
-        },
-        "inclusionInitiativesNarrative": {
-          "type": ["string", "null"],
+        "socialDialogueNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 2000,
-          "description": "Narrativ beskrivelse af igangværende initiativer."
+          "description": "Narrativ om engagement, træning og dialog med leverandørarbejdere."
+        },
+        "remediationNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2000,
+          "description": "Narrativ om afhjælpning og kompensation."
         }
       },
       "additionalProperties": false
@@ -2343,58 +2483,141 @@
     "S3": {
       "type": "object",
       "title": "S3Input",
-      "description": "Arbejdsmiljø og hændelser",
+      "description": "Berørte lokalsamfund",
       "properties": {
+        "communitiesIdentifiedCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Antal lokalsamfund identificeret som påvirkede."
+        },
+        "impactAssessmentsCoveragePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af aktiviteter med gennemført konsekvensanalyse."
+        },
+        "highRiskCommunitySharePercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af lokalsamfund klassificeret som højrisiko."
+        },
+        "grievancesOpenCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Åbne klager fra lokalsamfund."
+        },
         "incidents": {
           "type": "array",
           "maxItems": 40,
-          "description": "Registrerede arbejdsmiljøhændelser.",
+          "description": "Registrerede negative påvirkninger på lokalsamfund.",
           "items": {
             "type": "object",
-            "title": "S3Incident",
+            "title": "S3CommunityImpact",
             "properties": {
-              "incidentType": {
-                "type": "string",
-                "enum": ["fatality", "lostTime", "recordable", "nearMiss"],
-                "description": "Type af hændelse."
+              "community": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "maxLength": 160,
+                "description": "Navn eller beskrivelse af lokalsamfundet."
               },
-              "count": {
-                "type": ["number", "null"],
-                "minimum": 0,
-                "description": "Antal hændelser af typen."
+              "geography": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "maxLength": 120,
+                "description": "Land/region eller projektområde."
               },
-              "ratePerMillionHours": {
-                "type": ["number", "null"],
+              "impactType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "landRights",
+                  "environmentalDamage",
+                  "healthAndSafety",
+                  "culturalHeritage",
+                  "securityAndConflict",
+                  "other"
+                ],
+                "description": "Kategori for påvirkning."
+              },
+              "householdsAffected": {
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 0,
-                "description": "Rate pr. million arbejdstimer."
+                "description": "Antal berørte husholdninger."
+              },
+              "severityLevel": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "description": "Vurderet alvorlighed."
+              },
+              "remediationStatus": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "notStarted",
+                  "inProgress",
+                  "completed"
+                ],
+                "description": "Status på remediering."
               },
               "description": {
-                "type": ["string", "null"],
-                "maxLength": 240,
-                "description": "Kort beskrivelse eller lokation."
-              },
-              "rootCauseClosed": {
-                "type": ["boolean", "null"],
-                "description": "Angiver om rodårsagsanalyser er afsluttet."
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "maxLength": 500,
+                "description": "Kort beskrivelse af påvirkningen."
               }
             },
-            "required": ["incidentType"],
+            "required": [],
             "additionalProperties": false
           }
         },
-        "totalHoursWorked": {
-          "type": ["number", "null"],
-          "minimum": 0,
-          "description": "Arbejdstimer i rapporteringsåret."
-        },
-        "safetyCertification": {
-          "type": ["boolean", "null"],
-          "description": "Om virksomheden har arbejdsmiljøcertificering (fx ISO 45001)."
-        },
-        "safetyNarrative": {
-          "type": ["string", "null"],
+        "engagementNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 2000,
-          "description": "Narrativ opfølgning på arbejdsmiljøindsatser."
+          "description": "Narrativ om dialog og konsultationer (fx FPIC)."
+        },
+        "remedyNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2000,
+          "description": "Narrativ om afhjælpning og samarbejde med lokalsamfund."
         }
       },
       "additionalProperties": false
@@ -2402,60 +2625,164 @@
     "S4": {
       "type": "object",
       "title": "S4Input",
-      "description": "Due diligence og menneskerettigheder",
+      "description": "Forbrugere og slutbrugere",
       "properties": {
-        "processes": {
+        "productsAssessedPercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af produkter/tjenester med risikovurdering."
+        },
+        "severeIncidentsCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Antal alvorlige hændelser, der påvirker slutbrugere."
+        },
+        "recallsCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Antal produkt- eller service-recalls."
+        },
+        "complaintsResolvedPercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Andel af forbrugerklager løst inden for SLA."
+        },
+        "dataBreachesCount": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Antal registrerede brud på datasikkerhed."
+        },
+        "grievanceMechanismInPlace": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Om der findes hotline eller lignende for forbrugere/slutbrugere."
+        },
+        "escalationTimeframeDays": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Gennemsnitlig behandlingstid for forbrugerklager i dage."
+        },
+        "issues": {
           "type": "array",
           "maxItems": 40,
-          "description": "Kortlægning af due diligence-processer.",
+          "description": "Registrerede impacts på forbrugere/slutbrugere.",
           "items": {
             "type": "object",
-            "title": "S4Process",
+            "title": "S4ConsumerIssue",
             "properties": {
-              "area": {
-                "type": ["string", "null"],
+              "productOrService": {
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 160,
-                "description": "Område eller risikotype (fx leverandører)."
+                "description": "Produkt- eller servicenavn."
               },
-              "coveragePercent": {
-                "type": ["number", "null"],
-                "minimum": 0,
-                "maximum": 100,
-                "description": "Dækningsgrad i procent."
-              },
-              "lastAssessmentDate": {
-                "type": ["string", "null"],
+              "market": {
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 120,
-                "description": "Dato/år for seneste vurdering."
+                "description": "Marked eller segment."
+              },
+              "issueType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "productSafety",
+                  "dataPrivacy",
+                  "marketingPractices",
+                  "accessibility",
+                  "productQuality",
+                  "other"
+                ],
+                "description": "Kategori for hændelsen."
+              },
+              "usersAffected": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0,
+                "description": "Antal berørte slutbrugere."
               },
               "severityLevel": {
-                "type": ["string", "null"],
-                "enum": ["low", "medium", "high", null],
-                "description": "Vurderet risikoniveau."
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "description": "Vurderet alvorlighed."
               },
-              "remediationPlan": {
-                "type": ["string", "null"],
+              "remediationStatus": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "notStarted",
+                  "inProgress",
+                  "completed"
+                ],
+                "description": "Status på afhjælpning eller kompensation."
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 500,
-                "description": "Opsummering af plan for remediation."
+                "description": "Kort beskrivelse af hændelsen."
               }
             },
             "required": [],
             "additionalProperties": false
           }
         },
-        "grievanceMechanismInPlace": {
-          "type": ["boolean", "null"],
-          "description": "Om virksomheden har en klage-/henvendelsesmekanisme."
-        },
-        "escalationTimeframeDays": {
-          "type": ["number", "null"],
-          "minimum": 0,
-          "description": "Typisk behandlingstid i dage."
-        },
-        "dueDiligenceNarrative": {
-          "type": ["string", "null"],
+        "vulnerableUsersNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 2000,
-          "description": "Narrativ opsummering af due diligence-arbejdet."
+          "description": "Narrativ om støtte til udsatte brugergrupper."
+        },
+        "consumerEngagementNarrative": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2000,
+          "description": "Narrativ om kommunikation, uddannelse og samarbejde med slutbrugere."
         }
       },
       "additionalProperties": false
@@ -2474,22 +2801,41 @@
             "title": "G1Policy",
             "properties": {
               "topic": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 160,
                 "description": "Navn på politikken."
               },
               "status": {
-                "type": ["string", "null"],
-                "enum": ["approved", "inReview", "draft", "retired", "missing", null],
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "approved",
+                  "inReview",
+                  "draft",
+                  "retired",
+                  "missing",
+                  null
+                ],
                 "description": "Status for politikken."
               },
               "owner": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 160,
                 "description": "Ansvarlig rolle eller afdeling."
               },
               "lastReviewed": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 120,
                 "description": "Seneste gennemgangsdato."
               }
@@ -2507,38 +2853,65 @@
             "title": "G1Target",
             "properties": {
               "topic": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 160,
                 "description": "Navn på target."
               },
               "baselineYear": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 1990,
                 "maximum": 2100,
                 "description": "Baselineår for målet."
               },
               "targetYear": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "minimum": 1990,
                 "maximum": 2100,
                 "description": "Målår for opfyldelse."
               },
               "targetValue": {
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "description": "Talværdi for målet."
               },
               "unit": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 40,
                 "description": "Enhed for target (fx %)."
               },
               "status": {
-                "type": ["string", "null"],
-                "enum": ["onTrack", "lagging", "offTrack", "notStarted", null],
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "onTrack",
+                  "lagging",
+                  "offTrack",
+                  "notStarted",
+                  null
+                ],
                 "description": "Status for target."
               },
               "narrative": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "maxLength": 500,
                 "description": "Uddybende noter om target."
               }
@@ -2548,11 +2921,17 @@
           }
         },
         "boardOversight": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "Om bestyrelsen fører tilsyn med ESG/CSRD."
         },
         "governanceNarrative": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 2000,
           "description": "Narrativ om governance-struktur og roller."
         }

--- a/packages/shared/schema/index.ts
+++ b/packages/shared/schema/index.ts
@@ -14,8 +14,35 @@ export const e1EnergyMixOptions = ['electricity', 'districtHeat', 'steam', 'cool
 export const e1TargetScopeOptions = ['scope1', 'scope2', 'scope3', 'combined'] as const
 export const e1TargetStatusOptions = ['onTrack', 'lagging', 'atRisk'] as const
 export const e1ActionStatusOptions = ['planned', 'inProgress', 'delayed', 'completed'] as const
-export const s3IncidentTypeOptions = ['fatality', 'lostTime', 'recordable', 'nearMiss'] as const
-export const s4SeverityLevelOptions = ['low', 'medium', 'high'] as const
+export const remediationStatusOptions = ['notStarted', 'inProgress', 'completed'] as const
+export const s2IssueTypeOptions = [
+  'healthAndSafety',
+  'wagesAndBenefits',
+  'workingTime',
+  'freedomOfAssociation',
+  'childLabour',
+  'forcedLabour',
+  'discrimination',
+  'other'
+] as const
+export const s3ImpactTypeOptions = [
+  'landRights',
+  'environmentalDamage',
+  'healthAndSafety',
+  'culturalHeritage',
+  'securityAndConflict',
+  'other'
+] as const
+export const s4ConsumerIssueTypeOptions = [
+  'productSafety',
+  'dataPrivacy',
+  'marketingPractices',
+  'accessibility',
+  'productQuality',
+  'other'
+] as const
+export const incidentSeverityLevelOptions = ['low', 'medium', 'high'] as const
+export const s4SeverityLevelOptions = incidentSeverityLevelOptions
 export const g1PolicyStatusOptions = ['approved', 'inReview', 'draft', 'retired', 'missing'] as const
 export const g1TargetStatusOptions = ['onTrack', 'lagging', 'offTrack', 'notStarted'] as const
 
@@ -500,61 +527,83 @@ export const s1InputSchema = z
   })
   .strict()
 
-const s2DiversityRowSchema = z
+const s2ValueChainIncidentSchema = z
   .object({
-    level: z.string().max(120).nullable(),
-    femalePercent: z.number().min(0).max(100).nullable(),
-    malePercent: z.number().min(0).max(100).nullable(),
-    otherPercent: z.number().min(0).max(100).nullable(),
-    payGapPercent: z.number().min(-100).max(100).nullable(),
-    targetNarrative: z.string().max(500).nullable()
+    supplier: z.string().max(160).nullable(),
+    country: z.string().max(120).nullable(),
+    issueType: z.enum(s2IssueTypeOptions).nullable(),
+    workersAffected: z.number().min(0).nullable(),
+    severityLevel: z.enum(incidentSeverityLevelOptions).nullable(),
+    remediationStatus: z.enum(remediationStatusOptions).nullable(),
+    description: z.string().max(500).nullable()
   })
   .strict()
 
 export const s2InputSchema = z
   .object({
-    genderBalance: z.array(s2DiversityRowSchema).max(30).optional(),
-    dataCoveragePercent: z.number().min(0).max(100).nullable(),
-    equalityPolicyInPlace: z.boolean().nullable(),
-    inclusionInitiativesNarrative: z.string().max(2000).nullable()
+    valueChainWorkersCount: z.number().min(0).nullable(),
+    workersAtRiskCount: z.number().min(0).nullable(),
+    valueChainCoveragePercent: z.number().min(0).max(100).nullable(),
+    highRiskSupplierSharePercent: z.number().min(0).max(100).nullable(),
+    livingWageCoveragePercent: z.number().min(0).max(100).nullable(),
+    collectiveBargainingCoveragePercent: z.number().min(0).max(100).nullable(),
+    socialAuditsCompletedPercent: z.number().min(0).max(100).nullable(),
+    grievancesOpenCount: z.number().min(0).nullable(),
+    grievanceMechanismForWorkers: z.boolean().nullable(),
+    incidents: z.array(s2ValueChainIncidentSchema).max(40).optional(),
+    socialDialogueNarrative: z.string().max(2000).nullable(),
+    remediationNarrative: z.string().max(2000).nullable()
   })
   .strict()
 
-const s3IncidentSchema = z
+const s3CommunityImpactSchema = z
   .object({
-    incidentType: z.enum(s3IncidentTypeOptions),
-    count: z.number().min(0).nullable(),
-    ratePerMillionHours: z.number().min(0).nullable(),
-    description: z.string().max(240).nullable(),
-    rootCauseClosed: z.boolean().nullable()
+    community: z.string().max(160).nullable(),
+    geography: z.string().max(120).nullable(),
+    impactType: z.enum(s3ImpactTypeOptions).nullable(),
+    householdsAffected: z.number().min(0).nullable(),
+    severityLevel: z.enum(incidentSeverityLevelOptions).nullable(),
+    remediationStatus: z.enum(remediationStatusOptions).nullable(),
+    description: z.string().max(500).nullable()
   })
   .strict()
 
 export const s3InputSchema = z
   .object({
-    incidents: z.array(s3IncidentSchema).max(40).optional(),
-    totalHoursWorked: z.number().min(0).nullable(),
-    safetyCertification: z.boolean().nullable(),
-    safetyNarrative: z.string().max(2000).nullable()
+    communitiesIdentifiedCount: z.number().min(0).nullable(),
+    impactAssessmentsCoveragePercent: z.number().min(0).max(100).nullable(),
+    highRiskCommunitySharePercent: z.number().min(0).max(100).nullable(),
+    grievancesOpenCount: z.number().min(0).nullable(),
+    incidents: z.array(s3CommunityImpactSchema).max(40).optional(),
+    engagementNarrative: z.string().max(2000).nullable(),
+    remedyNarrative: z.string().max(2000).nullable()
   })
   .strict()
 
-const s4ProcessSchema = z
+const s4ConsumerIssueSchema = z
   .object({
-    area: z.string().max(160).nullable(),
-    coveragePercent: z.number().min(0).max(100).nullable(),
-    lastAssessmentDate: z.string().max(120).nullable(),
+    productOrService: z.string().max(160).nullable(),
+    market: z.string().max(120).nullable(),
+    issueType: z.enum(s4ConsumerIssueTypeOptions).nullable(),
+    usersAffected: z.number().min(0).nullable(),
     severityLevel: z.enum(s4SeverityLevelOptions).nullable(),
-    remediationPlan: z.string().max(500).nullable()
+    remediationStatus: z.enum(remediationStatusOptions).nullable(),
+    description: z.string().max(500).nullable()
   })
   .strict()
 
 export const s4InputSchema = z
   .object({
-    processes: z.array(s4ProcessSchema).max(40).optional(),
+    productsAssessedPercent: z.number().min(0).max(100).nullable(),
+    severeIncidentsCount: z.number().min(0).nullable(),
+    recallsCount: z.number().min(0).nullable(),
+    complaintsResolvedPercent: z.number().min(0).max(100).nullable(),
+    dataBreachesCount: z.number().min(0).nullable(),
     grievanceMechanismInPlace: z.boolean().nullable(),
     escalationTimeframeDays: z.number().min(0).nullable(),
-    dueDiligenceNarrative: z.string().max(2000).nullable()
+    issues: z.array(s4ConsumerIssueSchema).max(40).optional(),
+    vulnerableUsersNarrative: z.string().max(2000).nullable(),
+    consumerEngagementNarrative: z.string().max(2000).nullable()
   })
   .strict()
 
@@ -739,7 +788,10 @@ export type S3Input = z.infer<typeof s3InputSchema>
 export type S4Input = z.infer<typeof s4InputSchema>
 export type G1Input = z.infer<typeof g1InputSchema>
 
-export type S3IncidentType = (typeof s3IncidentTypeOptions)[number]
+export type RemediationStatus = (typeof remediationStatusOptions)[number]
+export type S2IssueType = (typeof s2IssueTypeOptions)[number]
+export type S3ImpactType = (typeof s3ImpactTypeOptions)[number]
+export type S4ConsumerIssueType = (typeof s4ConsumerIssueTypeOptions)[number]
 export type S4SeverityLevel = (typeof s4SeverityLevelOptions)[number]
 export type G1PolicyStatus = (typeof g1PolicyStatusOptions)[number]
 export type G1TargetStatus = (typeof g1TargetStatusOptions)[number]


### PR DESCRIPTION
## Summary
- align the shared S2/S3/S4 schema definitions and enums with official ESRS datapoints
- update the S2–S4 calculation modules, weights, and wizard steps to capture and score the new inputs
- refresh the related module docs and runbooks so support follows the revised workflows
- share the incident severity options across S2/S3 and upgrade the wizard incident descriptions to multiline inputs

## Testing
- pnpm --filter @org/shared test

------
https://chatgpt.com/codex/tasks/task_e_68e4c84f6a8083259b8c694665bfa386